### PR TITLE
fix: detect missing task forwardings after framework update

### DIFF
--- a/.ckeletin/scripts/expected-forwardings.txt
+++ b/.ckeletin/scripts/expected-forwardings.txt
@@ -1,0 +1,91 @@
+# Expected task forwardings from .ckeletin/Taskfile.yml → project Taskfile.yml
+# Each line is a framework task name that should have a project-level alias.
+# The post-update migration checks for missing entries and warns the user.
+#
+# Format: task-name (maps to ckeletin:task-name in framework Taskfile)
+# Lines starting with # are comments. Empty lines are ignored.
+
+# === Setup ===
+setup
+setup:all
+setup:pinned
+setup:latest
+
+# === Development ===
+doctor
+format
+lint
+tidy
+run
+install
+
+# === Build ===
+build
+build:dev
+build:prod
+build:release
+
+# === Test ===
+test
+test:unit
+test:race
+test:dev
+test:prod
+test:integration
+test:golden
+test:golden:update
+test:full
+test:watch
+test:fuzz
+test:release
+test:coverage:html
+
+# === Quality Checks ===
+check
+check:fast
+check:deps
+check:deps:checksum
+check:deps:outdated
+check:license
+check:license:source
+check:license:binary
+check:release
+check:sast
+check:sast:full
+check:sbom:vulns
+check:secrets
+check:tools:installed
+check:vuln
+
+# === Clean ===
+clean
+clean:local
+clean:release
+
+# === Generate ===
+generate:config:key-constants
+generate:config:schema
+generate:license
+generate:license:report
+generate:license:files
+generate:attribution
+generate:sbom
+
+# === Validate ===
+validate:constants
+validate:commands
+validate:defaults
+validate:layering
+validate:security
+validate:architecture
+validate:package-organization
+validate:config-consumption
+validate:output
+validate:task-naming
+
+# === Hook Aliases (used by .lefthook.yml) ===
+format:staged
+check:deps:verify
+check:secrets:staged
+check:vuln:fast
+test:coverage

--- a/.ckeletin/scripts/migrate-post-update.sh
+++ b/.ckeletin/scripts/migrate-post-update.sh
@@ -5,6 +5,8 @@
 
 set -eo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # Migration 1: Remove stale public component from .go-arch-lint.yml
 # When: pkg/ directory doesn't exist but .go-arch-lint.yml still references it
 if [ ! -d "pkg" ] && [ -f ".go-arch-lint.yml" ] && grep -q "pkg/\*\*" .go-arch-lint.yml; then
@@ -41,4 +43,39 @@ if [ -f "internal/ui/json.go" ] && grep -q "JSONEnvelope" internal/ui/json.go; t
     echo "     - Replace 'internal/ui' with '.ckeletin/pkg/output' for JSON types"
     echo "     - Affected: cmd/root.go, main.go, internal/check/executor.go"
     echo "     - Types moved: JSONEnvelope, JSONError, JSONResponder, IsJSONMode, SetOutputMode, etc."
+fi
+
+# Migration 3: Detect missing task forwardings in project Taskfile.yml
+# When: .ckeletin/Taskfile.yml has tasks that the project Taskfile doesn't forward
+# The expected-forwardings.txt file lists framework tasks that should have
+# project-level aliases. This runs on every update to catch new tasks.
+FORWARDINGS_FILE="$SCRIPT_DIR/expected-forwardings.txt"
+if [ -f "$FORWARDINGS_FILE" ] && [ -f "Taskfile.yml" ]; then
+    missing=()
+    while IFS= read -r task_name; do
+        # Skip empty lines and comments
+        [[ -z "$task_name" || "$task_name" == \#* ]] && continue
+        # Check if the project Taskfile has a forwarding for this task
+        if ! grep -q "^  ${task_name}:" Taskfile.yml 2>/dev/null; then
+            missing+=("$task_name")
+        fi
+    done < "$FORWARDINGS_FILE"
+
+    if [ ${#missing[@]} -gt 0 ]; then
+        echo ""
+        echo "   ⚠ Missing task forwardings in Taskfile.yml:"
+        echo "     The following framework tasks have no project-level alias."
+        echo "     Add these to your Taskfile.yml under '# === Convenience Aliases ===':"
+        echo ""
+        for task_name in "${missing[@]}"; do
+            # Derive description from framework Taskfile
+            desc=$(grep -A1 "^  ${task_name}:" .ckeletin/Taskfile.yml 2>/dev/null | grep "desc:" | sed 's/.*desc: //' | head -1)
+            echo "  ${task_name}:"
+            if [ -n "$desc" ]; then
+                echo "    desc: ${desc}"
+            fi
+            echo "    cmds: [task: ckeletin:${task_name}]"
+            echo ""
+        done
+    fi
 fi


### PR DESCRIPTION
## Summary

- Post-update migration now detects framework tasks missing from project Taskfile.yml
- Outputs exact YAML to add for each missing forwarding
- Uses `expected-forwardings.txt` manifest to track which tasks should be forwarded
- Idempotent — safe to run multiple times

Closes #86

## Test plan

- [x] No warnings on ckeletin-go itself (all tasks forwarded)
- [x] Correctly detects missing `generate:config:schema` when removed
- [x] Outputs valid YAML with desc and cmds for each missing task
- [x] All 1503 tests pass, coverage checks pass