### PR TITLE
fix(check): use reliable subcommand probe in check task

### DIFF
--- a/.ckeletin/Taskfile.yml
+++ b/.ckeletin/Taskfile.yml
@@ -1085,8 +1085,11 @@ tasks:
         vars: { CLI_ARGS: "" }
       - cmd: |
           # Check if binary has the 'check' subcommand (requires dev build tag).
+          # Use 'check --help' (NOT 'help check') as the probe: Cobra's `help`
+          # subcommand always exits 0 even for unknown topics, so it cannot detect
+          # a missing command. `check --help` exits non-zero when 'check' is absent.
           # Fall back to bash-based checks if not available.
-          if ./{{._BINARY_NAME}} help check >/dev/null 2>&1; then
+          if ./{{._BINARY_NAME}} check --help >/dev/null 2>&1; then
             ./{{._BINARY_NAME}} check {{.CLI_ARGS}}
           else
             echo "ℹ️  Binary does not have 'check' subcommand (dev build tag required)"


### PR DESCRIPTION
## What

Fixes the `check` task's dev-subcommand existence probe in `.ckeletin/Taskfile.yml`.

```diff
- if ./{{._BINARY_NAME}} help check >/dev/null 2>&1; then
+ if ./{{._BINARY_NAME}} check --help >/dev/null 2>&1; then
```

## Why (the bug)

The `check` task builds the dev binary, then probes for the dev-only `check` subcommand before deciding whether to run it or fall back to bash checks. The probe used `<binary> help check` — but **Cobra's `help` command always exits 0**, even for unknown topics. So the guard passed even when the binary had no `check` command, then ran `<binary> check` → `Error: unknown command "check"` → the task hard-failed, and the bash fallback was **never reached**.

In this repo it "worked by accident" (the `check` command exists). But **every downstream project scaffolded from the framework that lacks the dev-tagged `check` command** (e.g. focalc) had its `task check` hard-fail instead of gracefully falling back.

## The fix

Probe with `<binary> check --help`, which exits **non-zero** when the command is absent. Verified:
- `ping --help` → exit 0 (existing command)
- `<downstream> check --help` → exit 1 (missing command) → falls back to bash ✅
- `ckeletin-go check --help` → exit 0 → runs native check (unchanged)

A comment is added documenting the Cobra gotcha so the probe isn't reverted.

## Downstream impact

This lives in the vendored `.ckeletin/` tree, so downstream projects receive the fix via `task ckeletin:update` once this is merged to `main`.

---
ℹ️ Stacked on #97 (Go 1.26.3 security bump), which is required for the pre-push security gate to pass. Will retarget to `main` automatically when #97 merges.