### PR TITLE
fix: framework consumer footguns — scaffold pre-push hook (#100) + test-env cascade (#95)

### DIFF
--- a/.ckeletin/Taskfile.yml
+++ b/.ckeletin/Taskfile.yml
@@ -938,6 +938,7 @@ tasks:
   bench:
     desc: Run all benchmarks
     cmd: |
+      {{._TEST_ENV_PRELUDE}}
       go test -bench=. -benchmem ./... -run=^$ | tee bench-results.txt
       echo "Benchmark results saved to bench-results.txt"
     silent: false
@@ -945,16 +946,19 @@ tasks:
   bench:cmd:
     desc: Run benchmarks for cmd package
     cmd: |
+      {{._TEST_ENV_PRELUDE}}
       go test -bench=. -benchmem ./cmd -run=^$
 
   bench:config:
     desc: Run benchmarks for config package
     cmd: |
+      {{._TEST_ENV_PRELUDE}}
       go test -bench=. -benchmem ./.ckeletin/pkg/config -run=^$
 
   bench:logger:
     desc: Run benchmarks for logger package
     cmd: |
+      {{._TEST_ENV_PRELUDE}}
       go test -bench=. -benchmem ./.ckeletin/pkg/logger -run=^$
 
   # --- Fuzz Testing ---

--- a/.ckeletin/Taskfile.yml
+++ b/.ckeletin/Taskfile.yml
@@ -790,6 +790,12 @@ tasks:
     cmds:
       - '{{.SCRIPTS_DIR}}/validate-dev-build-tags.sh'
 
+  validate:hook-forwardings:
+    desc: Validate lefthook base hooks reference only namespaced or forwarded tasks (issue #100)
+    silent: true
+    cmds:
+      - '{{.SCRIPTS_DIR}}/validate-hook-forwardings.sh'
+
   # --- Testing ---
 
   test:
@@ -1065,6 +1071,7 @@ tasks:
       - task: validate:output
       - task: validate:security
       - task: validate:dev-build-tags
+      - task: validate:hook-forwardings
       - cmd: |
           source {{.SCRIPTS_DIR}}/lib/check-output.sh
           category_header "Security Scanning"
@@ -1142,6 +1149,7 @@ tasks:
       - task: validate:config-consumption
       - task: validate:output
       - task: validate:dev-build-tags
+      - task: validate:hook-forwardings
       - cmd: |
           source {{.SCRIPTS_DIR}}/lib/check-output.sh
           category_header "Tests (Unit Only)"

--- a/.ckeletin/Taskfile.yml
+++ b/.ckeletin/Taskfile.yml
@@ -32,6 +32,18 @@ vars:
   TEST_OUTPUT_JSON: "test-output.json"
   COVERAGE_TXT: "coverage.txt"
 
+  # Consumer test-env extension point (issue #95). Every test:* task sources this
+  # file — in the SAME shell as `go test` — before running, IF it exists. A
+  # consuming project defines its test-env isolation (XDG sandboxing, GO_TEST_FLAGS,
+  # fixtures, …) ONCE in this file, and every test:* task — current and future —
+  # inherits it. This removes the footgun of re-wrapping each test sibling by hand
+  # (Task does not cascade env: across `task:` delegation). Override the path with
+  # the CKELETIN_TEST_ENV_SETUP env var. Unset / missing file = no-op (back-compat).
+  # The `case` normalisation prefixes a bare filename with ./ so POSIX `.`
+  # (which searches $PATH, not cwd, for names without a slash — e.g. dash on
+  # Linux CI) reliably sources the cwd file instead of silently doing nothing.
+  _TEST_ENV_PRELUDE: '_ck_env="${CKELETIN_TEST_ENV_SETUP:-.ckeletin.test-env.sh}"; case "$_ck_env" in /*|./*|../*) ;; *) _ck_env="./$_ck_env";; esac; [ -f "$_ck_env" ] && . "$_ck_env";'
+
   # Scripts directory (relative to this Taskfile)
   SCRIPTS_DIR: '{{.TASKFILE_DIR}}/scripts'
 
@@ -802,6 +814,7 @@ tasks:
     desc: Run tests with coverage
     silent: true
     cmd: |
+      {{._TEST_ENV_PRELUDE}}
       gotestsum --format short --jsonfile {{.TEST_OUTPUT_JSON}} --hide-summary=skipped -- -v -tags dev -coverprofile=coverage.raw.txt -covermode=atomic -coverpkg=./...,{{._MODULE_PATH}}/.ckeletin/pkg/... ./... ./.ckeletin/pkg/...
       gocovmerge coverage.raw.txt > {{.COVERAGE_TXT}}
       rm -f coverage.raw.txt
@@ -810,6 +823,7 @@ tasks:
     desc: Run tests with dev commands (explicit - same as 'test')
     silent: true
     cmd: |
+      {{._TEST_ENV_PRELUDE}}
       gotestsum --format short --jsonfile {{.TEST_OUTPUT_JSON}} --hide-summary=skipped -- -v -tags dev -coverprofile=coverage.raw.txt -covermode=atomic -coverpkg=./...,{{._MODULE_PATH}}/.ckeletin/pkg/... ./... ./.ckeletin/pkg/...
       gocovmerge coverage.raw.txt > {{.COVERAGE_TXT}}
       rm -f coverage.raw.txt
@@ -818,6 +832,7 @@ tasks:
     desc: Run tests without dev commands (production mode)
     silent: true
     cmd: |
+      {{._TEST_ENV_PRELUDE}}
       gotestsum --format short --jsonfile {{.TEST_OUTPUT_JSON}} --hide-summary=skipped -- -v -coverprofile=coverage.raw.txt -covermode=atomic -coverpkg=./...,{{._MODULE_PATH}}/.ckeletin/pkg/... ./... ./.ckeletin/pkg/...
       gocovmerge coverage.raw.txt > {{.COVERAGE_TXT}}
       rm -f coverage.raw.txt
@@ -826,23 +841,27 @@ tasks:
     desc: Run unit tests only (skips integration tests)
     silent: true
     cmd: |
+      {{._TEST_ENV_PRELUDE}}
       gotestsum --format short --jsonfile {{.TEST_OUTPUT_JSON}} --hide-summary=skipped -- -v -short $(go list ./... | grep -v /test/integration)
 
   test:scaffold:
     desc: Run scaffold integration tests (slow — copies project, runs task check)
     silent: true
     cmd: |
+      {{._TEST_ENV_PRELUDE}}
       gotestsum --format short -- -v -tags "dev scaffold" -count=1 ./test/integration/...
 
   test:race:
     desc: Run tests with race detection
     cmd: |
+      {{._TEST_ENV_PRELUDE}}
       gotestsum --format standard-verbose --jsonfile {{.TEST_OUTPUT_JSON}} -- -v -race -tags dev ./...
 
   test:full:
     desc: Run all tests with both race detection and coverage
     silent: true
     cmd: |
+      {{._TEST_ENV_PRELUDE}}
       gotestsum --format short --jsonfile {{.TEST_OUTPUT_JSON}} --hide-summary=skipped -- -v -race -tags dev -coverprofile=coverage.raw.txt -covermode=atomic -coverpkg=./...,{{._MODULE_PATH}}/.ckeletin/pkg/... ./... ./.ckeletin/pkg/...
       gocovmerge coverage.raw.txt > {{.COVERAGE_TXT}}
       rm -f coverage.raw.txt
@@ -850,24 +869,27 @@ tasks:
   test:watch:
     desc: Run tests in watch mode
     cmd: |
+      {{._TEST_ENV_PRELUDE}}
       gotestsum --format short --watch --hide-summary=skipped
 
   test:integration:
     desc: Run integration tests (disables cache with -count=1)
     cmd: |
+      {{._TEST_ENV_PRELUDE}}
       gotestsum --format short -- -v -count=1 ./test/integration/...
 
   test:golden:
     desc: Test CLI output against golden files
     dir: .
     cmd: |
+      {{._TEST_ENV_PRELUDE}}
       go test ./test/integration -v -run Golden
 
   test:golden:update:
     desc: Update golden files (MUST manually review changes!)
     dir: .
     cmds:
-      - GOLDEN_UPDATE=1 go test ./test/integration -run Golden
+      - '{{._TEST_ENV_PRELUDE}} GOLDEN_UPDATE=1 go test ./test/integration -run Golden'
       - echo ""
       - echo "Review golden file changes before committing!"
       - echo "Run git diff test/integration/testdata/"
@@ -876,7 +898,7 @@ tasks:
   test:coverage:text:
     desc: Run tests with detailed coverage data
     cmds:
-      - gotestsum --format short --jsonfile {{.TEST_OUTPUT_JSON}} --hide-summary=skipped -- -cover -coverprofile=coverage.raw.txt -covermode=atomic -coverpkg=./...,{{._MODULE_PATH}}/.ckeletin/pkg/... ./... ./.ckeletin/pkg/...
+      - '{{._TEST_ENV_PRELUDE}} gotestsum --format short --jsonfile {{.TEST_OUTPUT_JSON}} --hide-summary=skipped -- -cover -coverprofile=coverage.raw.txt -covermode=atomic -coverpkg=./...,{{._MODULE_PATH}}/.ckeletin/pkg/... ./... ./.ckeletin/pkg/...'
       - gocovmerge coverage.raw.txt > {{.COVERAGE_TXT}}
       - rm -f coverage.raw.txt
       - echo "Detailed coverage report:"
@@ -940,6 +962,7 @@ tasks:
   test:fuzz:
     desc: Run all fuzz tests (default 10s per function)
     cmd: |
+      {{._TEST_ENV_PRELUDE}}
       FUZZTIME=${FUZZTIME:-10s}
       echo "Running fuzz tests for $FUZZTIME each..."
       go test -fuzz=FuzzValidateConfigValue -fuzztime=$FUZZTIME ./.ckeletin/pkg/config
@@ -950,12 +973,14 @@ tasks:
   test:fuzz:config:
     desc: Run fuzz tests for config package
     cmd: |
+      {{._TEST_ENV_PRELUDE}}
       FUZZTIME=${FUZZTIME:-10s}
       go test -fuzz=FuzzValidateConfigValue -fuzztime=$FUZZTIME ./.ckeletin/pkg/config
 
   test:fuzz:validator:
     desc: Run fuzz tests for validator package
     cmd: |
+      {{._TEST_ENV_PRELUDE}}
       FUZZTIME=${FUZZTIME:-10s}
       go test -fuzz=. -fuzztime=$FUZZTIME ./.ckeletin/pkg/config/validator
 

--- a/.ckeletin/configs/lefthook.base.yml
+++ b/.ckeletin/configs/lefthook.base.yml
@@ -33,5 +33,10 @@ pre-push:
   commands:
     coverage:
       run: task test:coverage
-    scaffold:
-      run: task test:scaffold
+    # NOTE: the scaffold-template integration test (`test:scaffold`) is a
+    # FRAMEWORK-AUTHOR concern — it validates ckeletin-go's own scaffold template.
+    # It is intentionally NOT defined here, because every consumer extends this
+    # base config: a bare `task test:scaffold` does not resolve downstream (the
+    # framework tasks are namespaced `ckeletin:*` there) and it would impose a
+    # multi-minute template test on every consumer push. ckeletin-go runs it via
+    # its own .lefthook.yml (using the namespaced `task ckeletin:test:scaffold`).

--- a/.ckeletin/scripts/validate-hook-forwardings.sh
+++ b/.ckeletin/scripts/validate-hook-forwardings.sh
@@ -18,14 +18,16 @@
 #
 # Exit 0 when consistent, 1 otherwise.
 
-set -o pipefail
+set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/check-output.sh
 source "${SCRIPT_DIR}/lib/check-output.sh"
 
 BASE_HOOKS=".ckeletin/configs/lefthook.base.yml"
-EXPECTED="${SCRIPT_DIR}/expected-forwardings.txt"
+# Overridable so tests can supply a controlled forwarding list (defaults to the
+# real SSOT next to this script).
+EXPECTED="${CKELETIN_EXPECTED_FORWARDINGS:-${SCRIPT_DIR}/expected-forwardings.txt}"
 
 check_header "Validating lefthook hooks reference only forwarded tasks (issue #100)"
 
@@ -39,8 +41,10 @@ if [ ! -f "$EXPECTED" ]; then
 fi
 
 # Extract task names referenced by `task <name>` in the base hooks. Comments are
-# stripped first (sed 's/#.*//') so prose mentioning a task name is not counted.
-REFERENCED=$(sed 's/#.*//' "$BASE_HOOKS" | grep -oE 'task [a-z][a-zA-Z0-9:_-]*' | awk '{print $2}' | sort -u)
+# stripped first (sed 's/#.*//'), and only `run:` directives are considered, so a
+# task name appearing in a desc: or prose is not mistaken for a hook reference.
+# `|| true`: an empty match must yield no references, not abort under `set -e`.
+REFERENCED=$(sed 's/#.*//' "$BASE_HOOKS" | grep -E '^[[:space:]]*run:' | grep -oE 'task [a-z][a-zA-Z0-9:_-]*' | awk '{print $2}' | sort -u || true)
 
 MISSING=""
 for task in $REFERENCED; do

--- a/.ckeletin/scripts/validate-hook-forwardings.sh
+++ b/.ckeletin/scripts/validate-hook-forwardings.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# .ckeletin/scripts/validate-hook-forwardings.sh
+#
+# Enforces consistency between the framework git hooks and the forwarding SSOT.
+#
+# Every consumer extends .ckeletin/configs/lefthook.base.yml, where the framework
+# tasks are namespaced `ckeletin:*`. A hook that runs a BARE `task <name>` only
+# resolves downstream if `<name>` has a project-level forwarding — i.e. it is
+# listed in expected-forwardings.txt (which migrate-post-update.sh ensures the
+# consumer's Taskfile.yml provides). If a base hook references a bare task that
+# is NOT in that list, the consumer's hook fails with "task does not exist" and
+# blocks every push (issue #100). This check makes that disagreement loud here,
+# in `task check`, instead of silently at a downstream's first push.
+#
+# A referenced task is OK when it is either:
+#   - namespaced `ckeletin:*` (resolves in any consumer), or
+#   - listed in expected-forwardings.txt (the consumer gets a forwarding).
+#
+# Exit 0 when consistent, 1 otherwise.
+
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/check-output.sh
+source "${SCRIPT_DIR}/lib/check-output.sh"
+
+BASE_HOOKS=".ckeletin/configs/lefthook.base.yml"
+EXPECTED="${SCRIPT_DIR}/expected-forwardings.txt"
+
+check_header "Validating lefthook hooks reference only forwarded tasks (issue #100)"
+
+if [ ! -f "$BASE_HOOKS" ]; then
+    echo "  ⏭️  $BASE_HOOKS not found — skipping"
+    exit 0
+fi
+if [ ! -f "$EXPECTED" ]; then
+    check_failure "expected-forwardings.txt not found" "$EXPECTED" "The forwarding SSOT is required to validate hook references"
+    exit 1
+fi
+
+# Extract task names referenced by `task <name>` in the base hooks. Comments are
+# stripped first (sed 's/#.*//') so prose mentioning a task name is not counted.
+REFERENCED=$(sed 's/#.*//' "$BASE_HOOKS" | grep -oE 'task [a-z][a-zA-Z0-9:_-]*' | awk '{print $2}' | sort -u)
+
+MISSING=""
+for task in $REFERENCED; do
+    case "$task" in
+        ckeletin:*) continue ;; # namespaced — resolves in every consumer
+    esac
+    if ! grep -Fxq "$task" "$EXPECTED"; then
+        MISSING="${MISSING}  ${task}"$'\n'
+    fi
+done
+MISSING="${MISSING%$'\n'}"
+
+if [ -n "$MISSING" ]; then
+    check_failure \
+        "Base hooks reference bare tasks with no forwarding" \
+        "$MISSING" \
+        "Each task a hook runs must resolve in a consumer. Either:"$'\n'"  - namespace it in lefthook.base.yml (task ckeletin:<name>), or"$'\n'"  - add <name> to .ckeletin/scripts/expected-forwardings.txt"
+    exit 1
+fi
+
+check_success "All base-hook task references are namespaced or forwarded"
+exit 0

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -29,6 +29,15 @@ extends:
   - .ckeletin/configs/lefthook.base.yml
 
 # Project-specific hooks (add below)
+
+# Framework-author concern: validate ckeletin-go's own scaffold template on push.
+# This lives here (not in the shared lefthook.base.yml) so consumers don't inherit
+# a multi-minute, non-resolving `task test:scaffold` hook. See issue #100.
+pre-push:
+  commands:
+    scaffold:
+      run: task ckeletin:test:scaffold
+
 commit-msg:
   commands:
     conventional-commit:

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -744,6 +744,45 @@ go tool cover -html=coverage.out
 - [Testify Documentation](https://pkg.go.dev/github.com/stretchr/testify) - Assertion library docs
 - [Table-Driven Tests in Go](https://dave.cheney.net/2019/05/07/prefer-table-driven-tests) - Dave Cheney's guide
 
+## Consumer Test Environment (Downstream Projects)
+
+Consuming projects often need to inject environment setup into the test runs
+that the framework's `test:*` tasks orchestrate — XDG sandboxing so tests never
+touch real user data, `GO_TEST_FLAGS`, custom fixtures, etc.
+
+**The footgun (and why this exists):** Task does not cascade `env:` blocks across
+`task: ckeletin:test:*` delegation — each task has an isolated env scope. The old
+workaround was to re-wrap *every* `test:*` sibling in the consumer's Taskfile with
+the same `mktemp`/`export`/`trap` boilerplate. Forgetting it on any new sibling
+(`test:race`, `test:fuzz`, …) silently dropped isolation — a regression that
+typically surfaced as "flaky CI" long after it was introduced (issue #95).
+
+**The mechanism:** every framework `test:*` task sources a single, consumer-owned
+file — in the *same shell* as `go test` — before running, **if it exists**:
+
+```sh
+.ckeletin.test-env.sh        # default path, at the consumer repo root
+```
+
+Define your isolation **once** there and every `test:*` task — current and future
+— inherits it. No per-sibling wrapping; nothing to forget.
+
+```sh
+# .ckeletin.test-env.sh  (committed — team-shared)
+_d=$(mktemp -d -t myproj-test.XXXXXX)
+export XDG_DATA_HOME="$_d" XDG_CONFIG_HOME="$_d" XDG_STATE_HOME="$_d"
+trap 'rm -rf "$_d"' EXIT
+```
+
+- Override the path with the `CKELETIN_TEST_ENV_SETUP` environment variable.
+- No file → no-op (fully backward compatible).
+- **Enforcement:** a framework test (`TestTestEnvPrelude_AllTestTasksWired`) fails
+  if any `test:*` task that runs `go test` is missing the prelude, so the
+  isolation hook can never silently regress as new test tasks are added.
+- **Belt-and-suspenders:** keep a sentinel test (e.g. asserting `XDG_DATA_HOME`
+  points outside the real home) so a *missing* `.ckeletin.test-env.sh` fails
+  loudly rather than polluting real user data.
+
 ## Summary Checklist
 
 Before submitting code, ensure your tests:

--- a/test/integration/hook_forwardings_test.go
+++ b/test/integration/hook_forwardings_test.go
@@ -26,11 +26,13 @@ func hfScriptPath(t *testing.T) string {
 	return p
 }
 
-// runHookForwardings runs the validator with the given working directory.
-func runHookForwardings(t *testing.T, dir string) (string, int) {
+// runHookForwardings runs the validator in dir. Extra "KEY=value" env entries
+// (e.g. CKELETIN_EXPECTED_FORWARDINGS) may be supplied to keep tests hermetic.
+func runHookForwardings(t *testing.T, dir string, env ...string) (string, int) {
 	t.Helper()
 	cmd := exec.Command("bash", hfScriptPath(t))
 	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), env...)
 	out, err := cmd.CombinedOutput()
 	if ee, ok := err.(*exec.ExitError); ok {
 		return string(out), ee.ExitCode()
@@ -63,7 +65,11 @@ func TestHookForwardings_DetectsUnforwardedBareTask(t *testing.T) {
 	base := "pre-push:\n  commands:\n    scaffold:\n      run: task test:scaffold\n"
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".ckeletin", "configs", "lefthook.base.yml"), []byte(base), 0o644))
 
-	out, code := runHookForwardings(t, dir)
+	// Hermetic forwarding list that deliberately omits test:scaffold.
+	expected := filepath.Join(dir, "expected.txt")
+	require.NoError(t, os.WriteFile(expected, []byte("# forwardings\nlint\ntest:coverage\n"), 0o644))
+
+	out, code := runHookForwardings(t, dir, "CKELETIN_EXPECTED_FORWARDINGS="+expected)
 	assert.Equal(t, 1, code, "an unforwarded bare task reference must fail.\nOutput:\n%s", out)
 	assert.Contains(t, out, "test:scaffold", "should name the offending task")
 	assert.Contains(t, out, "no forwarding", "should explain the failure")

--- a/test/integration/hook_forwardings_test.go
+++ b/test/integration/hook_forwardings_test.go
@@ -1,0 +1,85 @@
+package integration
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// hfProjectRoot returns the absolute project root (two levels up).
+func hfProjectRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs("../..")
+	require.NoError(t, err, "failed to resolve project root")
+	return root
+}
+
+// hfScriptPath returns the absolute path to validate-hook-forwardings.sh.
+func hfScriptPath(t *testing.T) string {
+	t.Helper()
+	p := filepath.Join(hfProjectRoot(t), ".ckeletin", "scripts", "validate-hook-forwardings.sh")
+	require.FileExists(t, p, "validate-hook-forwardings script must exist")
+	return p
+}
+
+// runHookForwardings runs the validator with the given working directory.
+func runHookForwardings(t *testing.T, dir string) (string, int) {
+	t.Helper()
+	cmd := exec.Command("bash", hfScriptPath(t))
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if ee, ok := err.(*exec.ExitError); ok {
+		return string(out), ee.ExitCode()
+	}
+	require.NoError(t, err, "validator errored.\nOutput:\n%s", string(out))
+	return string(out), 0
+}
+
+// TestHookForwardings_PassesOnFramework guards that ckeletin-go's own base hooks
+// reference only namespaced or forwarded tasks (issue #100). Exit 0.
+func TestHookForwardings_PassesOnFramework(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping hook-forwardings integration test in short mode")
+	}
+	out, code := runHookForwardings(t, hfProjectRoot(t))
+	assert.Equal(t, 0, code, "framework base hooks must be consistent.\nOutput:\n%s", out)
+	assert.Contains(t, out, "namespaced or forwarded")
+}
+
+// TestHookForwardings_DetectsUnforwardedBareTask asserts a base hook that runs a
+// bare task with no forwarding (the exact #100 breakage: `task test:scaffold`)
+// is flagged. The script reads the real expected-forwardings.txt, so a temp
+// base.yml referencing a task absent from it must fail.
+func TestHookForwardings_DetectsUnforwardedBareTask(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping hook-forwardings integration test in short mode")
+	}
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".ckeletin", "configs"), 0o755))
+	base := "pre-push:\n  commands:\n    scaffold:\n      run: task test:scaffold\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".ckeletin", "configs", "lefthook.base.yml"), []byte(base), 0o644))
+
+	out, code := runHookForwardings(t, dir)
+	assert.Equal(t, 1, code, "an unforwarded bare task reference must fail.\nOutput:\n%s", out)
+	assert.Contains(t, out, "test:scaffold", "should name the offending task")
+	assert.Contains(t, out, "no forwarding", "should explain the failure")
+}
+
+// TestHookForwardings_AllowsNamespacedTask asserts a base hook that runs a
+// namespaced `ckeletin:*` task is accepted (it resolves in any consumer).
+func TestHookForwardings_AllowsNamespacedTask(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping hook-forwardings integration test in short mode")
+	}
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".ckeletin", "configs"), 0o755))
+	base := "pre-push:\n  commands:\n    scaffold:\n      run: task ckeletin:test:scaffold\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".ckeletin", "configs", "lefthook.base.yml"), []byte(base), 0o644))
+
+	out, code := runHookForwardings(t, dir)
+	assert.Equal(t, 0, code, "a namespaced task reference must pass.\nOutput:\n%s", out)
+}

--- a/test/integration/test_env_prelude_test.go
+++ b/test/integration/test_env_prelude_test.go
@@ -1,0 +1,123 @@
+package integration
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// teProjectRoot returns the absolute project root.
+func teProjectRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs("../..")
+	require.NoError(t, err, "failed to resolve project root")
+	return root
+}
+
+func teFrameworkTaskfile(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(teProjectRoot(t), ".ckeletin", "Taskfile.yml"))
+	require.NoError(t, err, "failed to read framework Taskfile")
+	return string(b)
+}
+
+// extractPrelude returns the actual _TEST_ENV_PRELUDE var value from the
+// framework Taskfile, so the mechanism test exercises the real string (no
+// duplication / drift).
+func extractPrelude(t *testing.T) string {
+	t.Helper()
+	for line := range strings.SplitSeq(teFrameworkTaskfile(t), "\n") {
+		s := strings.TrimSpace(line)
+		if after, ok := strings.CutPrefix(s, "_TEST_ENV_PRELUDE:"); ok {
+			v := strings.TrimSpace(after)
+			v = strings.TrimPrefix(v, "'")
+			v = strings.TrimSuffix(v, "'")
+			return v
+		}
+	}
+	t.Fatal("_TEST_ENV_PRELUDE not found in framework Taskfile")
+	return ""
+}
+
+// TestTestEnvPrelude_SourcesFileWhenPresent asserts the real prelude string
+// sources .ckeletin.test-env.sh (in the same shell) when it exists — verified
+// in POSIX sh, which is what Task uses.
+func TestTestEnvPrelude_SourcesFileWhenPresent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test-env prelude integration test in short mode")
+	}
+	prelude := extractPrelude(t)
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "sourced.marker")
+	envFile := "export CKELETIN_TEST_ENV_PROBE=active\ntouch " + marker + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".ckeletin.test-env.sh"), []byte(envFile), 0o644))
+
+	cmd := exec.Command("sh", "-c", prelude+` printf 'PROBE=%s\n' "$CKELETIN_TEST_ENV_PROBE"`)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "prelude run failed.\nOutput:\n%s", out)
+	assert.FileExists(t, marker, "the test-env file must be sourced (marker created)")
+	assert.Contains(t, string(out), "PROBE=active", "sourced exports must be visible to the test shell")
+}
+
+// TestTestEnvPrelude_NoOpWhenAbsent asserts the prelude is a clean no-op (exit 0,
+// no error) when no test-env file is present — backward compatibility.
+func TestTestEnvPrelude_NoOpWhenAbsent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test-env prelude integration test in short mode")
+	}
+	prelude := extractPrelude(t)
+	dir := t.TempDir() // no .ckeletin.test-env.sh here
+
+	cmd := exec.Command("sh", "-c", prelude+` echo ran`)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "prelude must not fail when the file is absent.\nOutput:\n%s", out)
+	assert.Contains(t, string(out), "ran")
+}
+
+// TestTestEnvPrelude_AllTestTasksWired is the anti-rot guard (issue #95): every
+// test:* task that invokes `go test`/`gotestsum` directly MUST include the
+// prelude, so a newly-added sibling cannot silently lose the consumer's test-env
+// isolation. Tasks that delegate (task: test / deps: [test]) are exempt.
+func TestTestEnvPrelude_AllTestTasksWired(t *testing.T) {
+	content := teFrameworkTaskfile(t)
+	lines := strings.Split(content, "\n")
+	taskHeader := regexp.MustCompile(`^  ([a-zA-Z][a-zA-Z0-9:_-]*):\s*$`)
+
+	var curName string
+	var body []string
+	var offenders []string
+
+	flush := func() {
+		if curName == "" {
+			return
+		}
+		joined := strings.Join(body, "\n")
+		runsGoTest := strings.Contains(joined, "gotestsum ") || strings.Contains(joined, "go test ")
+		if strings.HasPrefix(curName, "test") && runsGoTest && !strings.Contains(joined, "_TEST_ENV_PRELUDE") {
+			offenders = append(offenders, curName)
+		}
+	}
+
+	for _, line := range lines {
+		if m := taskHeader.FindStringSubmatch(line); m != nil {
+			flush()
+			curName = m[1]
+			body = nil
+			continue
+		}
+		body = append(body, line)
+	}
+	flush()
+
+	assert.Empty(t, offenders,
+		"these test:* tasks run go test but are missing {{._TEST_ENV_PRELUDE}} "+
+			"(consumers would lose test-env isolation on them — issue #95): %v", offenders)
+}

--- a/test/integration/test_env_prelude_test.go
+++ b/test/integration/test_env_prelude_test.go
@@ -101,7 +101,8 @@ func TestTestEnvPrelude_AllTestTasksWired(t *testing.T) {
 		}
 		joined := strings.Join(body, "\n")
 		runsGoTest := strings.Contains(joined, "gotestsum ") || strings.Contains(joined, "go test ")
-		if strings.HasPrefix(curName, "test") && runsGoTest && !strings.Contains(joined, "_TEST_ENV_PRELUDE") {
+		inScope := strings.HasPrefix(curName, "test") || strings.HasPrefix(curName, "bench")
+		if inScope && runsGoTest && !strings.Contains(joined, "_TEST_ENV_PRELUDE") {
 			offenders = append(offenders, curName)
 		}
 	}


### PR DESCRIPTION
Closes #100. Closes #95.

Two consumer-facing framework footguns, both surfaced by downstream projects (vaultmind), fixed with the manifesto lens (root cause + automated enforcement, not docs/remember-to).

### #100 — scaffold pre-push hook blocks every consumer push
The shared `.ckeletin/configs/lefthook.base.yml` ran a bare `task test:scaffold` pre-push hook. In a consumer the framework tasks are namespaced `ckeletin:*`, so the bare task does not resolve → the hook fails and blocks every `git push`. It's also a framework-author concern (validates ckeletin-go's own template) wrongly imposed on consumers.
- Moved the hook out of the inherited `lefthook.base.yml` into ckeletin-go's own `.lefthook.yml` (`task ckeletin:test:scaffold`).
- Added `validate:hook-forwardings` (wired into the check suite): every task a base hook runs must be namespaced or listed in `expected-forwardings.txt`, so this class can't recur.

### #95 — test:* env cascade footgun
Task doesn't cascade `env:` across `task: ckeletin:test:*` delegation, so consumers had to re-wrap every test sibling with mktemp/export/trap; forgetting it on a new sibling silently dropped test isolation (flaky CI for weeks).
- Added a single sourced `_TEST_ENV_PRELUDE` extension point: every `test:*`/`bench:*` task sources a consumer-owned `.ckeletin.test-env.sh` (override `CKELETIN_TEST_ENV_SETUP`) in the same shell as `go test`, if it exists. Define isolation **once**; every task — current and future — inherits it. No file = no-op.
- Path is `./`-normalised so POSIX `.` (dash on Linux CI) sources reliably.
- `TestTestEnvPrelude_AllTestTasksWired` enforces the prelude on every test/bench task that runs go test — anti-rot guard.
- Consumer guidance in `docs/testing-guide.md`.

Both live under `.ckeletin/`, so consumers receive them via `task ckeletin:update`. Independent code review applied (2 medium + 2 low addressed: bench isolation, `set -eo pipefail`, `run:`-only extraction, hermetic test). Full `task check` green.

---
Note: issue **#96** (`.claude/hooks.json` → `settings.json`) is intentionally **not** in this PR — writing `.claude/settings.json` is blocked by the agent self-modification guard; pending maintainer action.