### PR TITLE
chore(conform): comply with CKSPEC 0.5.0 (map CKSPEC-OUT-006)

### DIFF
--- a/conformance-mapping.yaml
+++ b/conformance-mapping.yaml
@@ -2,7 +2,7 @@
 # Used by `task conform` to generate the conformance report.
 # Format agreed between ckeletin-go and ckeletin-rust architects.
 
-spec_version: "0.4.0"
+spec_version: "0.5.0"
 
 requirements:
   # ═══════════════════════════════════════════════════════════════
@@ -316,6 +316,24 @@ requirements:
       - "task validate:output"
     violation_tests:
       - "test/conformance/violation_test.go::TestViolation_OUT005_BusinessUsesFmtPrint"
+
+  CKSPEC-OUT-006:
+    title: "Build identity in version output"
+    status: met
+    enforcement_level: test
+    evidence: >
+      cmd/root.go composes RootCmd.Version as
+      "<version>, commit <commit>, built at <date>" from the Version, Commit and
+      Date package vars injected via ldflags (see Taskfile.yml LDFLAGS). So
+      `<binary> --version` emits all three build-identity fields; TestVersionFlag
+      asserts the commit and build-date fields are present in the output.
+    checks:
+      - "grep -qE 'commit %s, built at %s' cmd/root.go"
+    violation_tests: []
+    violation_evidence: >
+      Removing any build-identity field from the cmd/root.go version template (or
+      dropping its ldflags injection) takes it out of `--version`; both the grep
+      check and TestVersionFlag fail, so the regression cannot land green.
 
   # ═══════════════════════════════════════════════════════════════
   # Agent Readiness (CKSPEC-AGENT-001 through CKSPEC-AGENT-005)

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -292,10 +292,13 @@ func TestVersionFlag(t *testing.T) {
 	require.NoError(t, err, "version command should succeed")
 
 	output := stdout.String()
-	// Version output should contain version info
+	// CKSPEC-OUT-006: the version output MUST carry build identity — version,
+	// commit, and build date (composed in cmd/root.go from ldflags-injected vars).
 	hasVersion := strings.Contains(output, "version") || strings.Contains(output, "dev")
 	assert.True(t, hasVersion,
 		"version output should contain 'version' or 'dev', got: %s", output)
+	assert.Contains(t, output, "commit", "version output must include build identity (commit), got: %s", output)
+	assert.Contains(t, output, "built at", "version output must include build identity (build date), got: %s", output)
 }
 
 // TestConfigLoading tests configuration loading from files


### PR DESCRIPTION
The spec-of-record (`peiman/ckeletin`) advanced **0.4.0 → 0.5.0**, adding **`CKSPEC-OUT-006` "Build identity in version output"** (level MUST). `task conform` flagged it as unmapped (CKSPEC-ENF-005 violation) → red.

ckeletin-go already **satisfies** it — `cmd/root.go` composes `RootCmd.Version` as `"<version>, commit <commit>, built at <date>"` from ldflags-injected vars. The gap was the stale conformance mapping.

- Map `CKSPEC-OUT-006` (`status: met`) with a deterministic grep check on the version template + `violation_evidence`.
- Bump `spec_version` 0.4.0 → 0.5.0.
- Strengthen `TestVersionFlag` to assert the `commit`/`built at` build-identity fields are present.

`task conform` now passes **36/36 requirements at spec 0.5.0**.

> Detection mechanism, for reference: `task conform` fetches `peiman/ckeletin`'s `spec/requirements.json` (main) and fails on version mismatch or any unmapped requirement.