### PR TITLE
feat(ci): conformance release gate + weekly drift detector (ENF-009)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ on:
   schedule:
     - cron: '0 0 * * 0'  # Weekly on Sunday at midnight UTC (catch upstream license changes)
 
+  workflow_dispatch: {} # Allow manual runs (e.g. to verify the conformance gate)
+
 # Concurrency controls to prevent wasting CI minutes
 # Cancel in-progress runs for PRs, but let main branch builds complete
 concurrency:
@@ -369,14 +371,92 @@ jobs:
           retention-days: 30
 
   # ═══════════════════════════════════════════════════════════════════
-  # RELEASE (Tags only - requires test-matrix + build to pass)
+  # CONFORMANCE GATE (CKSPEC-ENF-009)
+  # Verifies conformance against the LATEST published ckeletin spec.
+  # Runs on the release path (tags) to GATE releases, and weekly to DETECT
+  # drift (opening an issue). NOT on pull_request — an external spec release
+  # must never break an unrelated PR. The spec mandates only the property
+  # ("continuously verify + block release on non-conformance"); CI is this
+  # project's chosen mechanism.
+  # ═══════════════════════════════════════════════════════════════════
+  conformance:
+    name: CKSPEC Conformance
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      issues: write # open a drift issue on scheduled failure
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: '.go-version' # SSOT for Go version
+          cache-dependency-path: 'go.sum'
+
+      - name: Cache Task Binary
+        id: cache-task
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.local/bin/task
+          key: ${{ runner.os }}-task-${{ env.TASK_VERSION }}
+
+      - name: Install Task
+        if: steps.cache-task.outputs.cache-hit != 'true'
+        run: |
+          INSTALL_DIR="$HOME/.local/bin"
+          mkdir -p "$INSTALL_DIR"
+          curl -sL "https://taskfile.dev/install.sh" | sh -s -- -b "$INSTALL_DIR" v${{ env.TASK_VERSION }}
+        shell: bash
+
+      - name: Add tools to PATH
+        run: |
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+
+      - name: Cache Dev Tools (pinned versions)
+        id: cache-devtools
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/go/bin
+          key: ${{ runner.os }}-devtools-${{ hashFiles('.go-version', '.ckeletin/Taskfile.yml') }}-${{ env.PINNED_TOOLS_VERSION }}
+
+      - name: Install Pinned Tools
+        if: steps.cache-devtools.outputs.cache-hit != 'true'
+        run: task setup:pinned
+
+      - name: Install Latest Tools
+        run: task setup:latest
+
+      - name: Run CKSPEC conformance against the latest spec (ENF-009 gate)
+        run: task conform
+
+      - name: Open drift issue (scheduled runs only)
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TITLE="Conformance drift: project no longer conforms to the latest ckeletin spec"
+          # Only open an issue if one is not already open (avoid weekly duplicates).
+          OPEN=$(gh issue list --state open --search "$TITLE" --json number --jq 'length')
+          if [ "$OPEN" = "0" ]; then
+            RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            gh issue create --title "$TITLE" \
+              --body "The weekly CKSPEC conformance check failed — this project has drifted from the latest published spec (peiman/ckeletin). Run \`task conform\` locally and reconcile conformance-mapping.yaml. Run log: $RUN_URL"
+          fi
+
+  # ═══════════════════════════════════════════════════════════════════
+  # RELEASE (Tags only - requires test-matrix + build + conformance to pass)
   # Creates GitHub releases with cross-platform binaries via GoReleaser
   # ═══════════════════════════════════════════════════════════════════
   release:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: startsWith(github.ref, 'refs/tags/') # Only run on tags
-    needs: [test-matrix, build] # Ensure all tests pass before release
+    needs: [test-matrix, build, conformance] # Tests + conformance must pass before release
     permissions:
       contents: write # Need write access to create releases
       packages: read # For package access if needed


### PR DESCRIPTION
Closes the loop: detection (ENF-005) + evidence integrity (ENF-008) only matter if conformance is **enforced**.

Adds a `conformance` CI job running `task conform` against the **latest** published ckeletin spec:
- **Tags → gates the release.** `release` now `needs: [test-matrix, build, conformance]` — a non-conforming release can't ship.
- **Weekly schedule → drift detector.** Catches the spec moving with no release in flight; opens a **deduped** issue on failure.
- **Not on PRs** — an external spec release must never red an unrelated PR.
- **workflow_dispatch** — manual verification of the gate.

Mechanism is the project's choice (CI); the spec mandates only the property. `actionlint` clean. The conformance job is skipped on normal PR/push events, so this PR's CI behavior is unchanged.

> Follow-up: codify `CKSPEC-ENF-008` + `ENF-009` into the `peiman/ckeletin` spec-of-record (their `checks:` point at this tooling + the `conformance` job).