### PR TITLE
fix: deterministic scaffold pre-push (hermetic deps test) + semgrep in conformance CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,6 +431,9 @@ jobs:
       - name: Install Latest Tools
         run: task setup:latest
 
+      - name: Install semgrep
+        run: pip3 install --user semgrep # SAST tool the conformance violation tests (ENF-006) invoke
+
       - name: Run CKSPEC conformance against the latest spec (ENF-009 gate)
         run: task conform
 

--- a/test/integration/check_command_test.go
+++ b/test/integration/check_command_test.go
@@ -61,6 +61,33 @@ func buildDevBinary(t *testing.T) string {
 	return devBinaryPath
 }
 
+// ensureLicenseCheckBinary guarantees ./ckeletin-go exists in the project root for
+// the duration of the test. The license-binary check (part of
+// `check --category dependencies`) scans the built binary by name, mirroring how
+// `task check` runs build:dev before the check. Without this, the deps test passes
+// or fails depending on whether a prior `task build` happened to leave a binary
+// behind — a hidden state dependency that makes the test non-deterministic across
+// environments (CI build job and fresh worktrees disagree). Builds the binary only
+// if it is absent and removes only what it created, so a developer's existing
+// ./ckeletin-go is never clobbered.
+func ensureLicenseCheckBinary(t *testing.T, root string) {
+	t.Helper()
+
+	// "ckeletin-go" mirrors the binaryName default in cmd/root.go and
+	// internal/check/executor.go — the name license-binary scans as ./<binaryName>.
+	binaryPath := filepath.Join(root, "ckeletin-go")
+	if _, err := os.Stat(binaryPath); err == nil {
+		return // already present (e.g. from a prior `task build`); leave it in place
+	}
+
+	cmd := exec.Command("go", "build", "-tags", "dev", "-o", binaryPath, ".")
+	cmd.Dir = root
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "Failed to build ./ckeletin-go for license-binary check: %s", string(output))
+
+	t.Cleanup(func() { _ = os.Remove(binaryPath) })
+}
+
 // TestCheckCommand_QualityCategory runs the check command with --category quality.
 // This exercises the highest-impact uncovered code paths:
 //   - Executor.Execute (orchestration)
@@ -116,6 +143,7 @@ func TestCheckCommand_DepsCategory(t *testing.T) {
 
 	binary := buildDevBinary(t)
 	root := projectRoot(t)
+	ensureLicenseCheckBinary(t, root) // license-binary scans ./ckeletin-go; build it if absent
 
 	cmd := exec.Command(binary, "check", "--category", "dependencies")
 	cmd.Dir = root


### PR DESCRIPTION
Two reliability fixes surfaced while verifying the ENF-009 conformance release gate end-to-end.

## 1. `fix(test)` — remove hidden binary dependency in the deps-check test
`TestCheckCommand_DepsCategory` runs `check --category dependencies`, whose `license-binary` sub-check scans `./ckeletin-go` **by name**. The test only built a *dev* binary at a temp path, so it passed only when a prior `task build` had left `./ckeletin-go` in the project root — and failed otherwise (fresh worktrees, clean state). That made the **scaffold pre-push hook non-deterministic**.

Diagnosed with a 5×-parallel isolated flake-hunt: all 5 runs failed *identically* on `license-binary → "Binary not found: ./ckeletin-go"` (0 network-related) — i.e. not a flake, a hidden state dependency.

Fix: `ensureLicenseCheckBinary` builds `./ckeletin-go` when absent (mirroring the `build:dev` step `task check` runs before the check) and cleans up only what it created, so a developer's existing binary is never clobbered. Verified red→green: with the binary moved aside the test now builds it and passes.

## 2. `fix(ci)` — install semgrep in the conformance job
The `conformance` job runs `task conform`, which executes the ENF-006 violation tests (`go test -tags conformance ./test/conformance/...`). Those tests invoke `semgrep`, which wasn't installed in that job — so the ENF-009 gate failed on its first `workflow_dispatch` run (the gate correctly caught its own missing setup). Adds `pip3 install --user semgrep` before the conform step.

## Verification
- `task check` ✅ All 23 checks passed
- deps test red→green confirmed (binary-absent → builds + passes)
- pre-push scaffold + coverage green (this PR pushed cleanly after two prior flaky rejections)
- conformance job to be re-verified via `workflow_dispatch` after merge