### PR TITLE
ci: reusable workflows — nightly-guarded matrix + standalone conformance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ on:
   schedule:
     - cron: '0 0 * * 0'  # Weekly on Sunday at midnight UTC (catch upstream license changes)
 
-  workflow_dispatch: {} # Allow manual runs (e.g. to verify the conformance gate)
+  workflow_dispatch: {} # Allow manual runs (conformance → conformance.yml, matrix → nightly.yml)
 
 # Concurrency controls to prevent wasting CI minutes
 # Cancel in-progress runs for PRs, but let main branch builds complete
@@ -78,92 +78,24 @@ jobs:
           deny-licenses: GPL-2.0-only, GPL-3.0-only, AGPL-3.0-only
 
   # ═══════════════════════════════════════════════════════════════════
-  # MULTI-OS TESTING (Main + Releases only - expensive runners)
-  # Tests across Ubuntu, macOS, and Windows to catch platform-specific issues
+  # MULTI-OS TESTING (Tags / release gate only - expensive runners)
+  # Cross-platform tests GATE releases. Per-merge runs are dropped; nightly.yml
+  # runs this matrix between releases when commits land (change-guarded) and is
+  # dispatchable there on demand. PRs use the fast single-platform check in
+  # `build`. Steps live in reusable-test-matrix.yml (SSOT).
   # ═══════════════════════════════════════════════════════════════════
   test-matrix:
-    name: Test on ${{ matrix.os }}
-    if: github.event_name != 'pull_request'
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    name: Test
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
-        with:
-          go-version-file: '.go-version'  # SSOT for Go version
-          cache-dependency-path: 'go.sum'
-
-      - name: Download Dependencies
-        run: go mod download
-
-      - name: Install Task (Unix)
-        if: runner.os != 'Windows'
-        run: |
-          INSTALL_DIR="$HOME/.local/bin"
-          mkdir -p "$INSTALL_DIR"
-          curl -sL https://taskfile.dev/install.sh | sh -s -- -b "$INSTALL_DIR" v${{ env.TASK_VERSION }}
-          echo "$INSTALL_DIR" >> "$GITHUB_PATH"
-        shell: bash
-
-      - name: Install Task (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          $INSTALL_DIR = "$env:USERPROFILE\.local\bin"
-          New-Item -ItemType Directory -Force -Path $INSTALL_DIR
-          $TASK_URL = "https://github.com/go-task/task/releases/download/v${{ env.TASK_VERSION }}/task_windows_amd64.zip"
-          Invoke-WebRequest -Uri $TASK_URL -OutFile task.zip
-          Expand-Archive -Path task.zip -DestinationPath $INSTALL_DIR -Force
-          Remove-Item task.zip
-          echo "$INSTALL_DIR" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        shell: pwsh
-
-      - name: Verify Task Installation
-        run: task --version
-
-      - name: Cache Dev Tools (pinned versions)
-        id: cache-devtools
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
-        with:
-          path: ~/go/bin
-          key: ${{ runner.os }}-devtools-${{ hashFiles('.go-version', '.ckeletin/Taskfile.yml') }}-${{ env.PINNED_TOOLS_VERSION }}
-
-      - name: Add Go bin to PATH (Unix)
-        if: runner.os != 'Windows'
-        run: echo "$HOME/go/bin" >> "$GITHUB_PATH"
-
-      - name: Add Go bin to PATH (Windows)
-        if: runner.os == 'Windows'
-        run: echo "$env:USERPROFILE\go\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        shell: pwsh
-
-      - name: Install Pinned Tools
-        if: steps.cache-devtools.outputs.cache-hit != 'true'
-        run: task setup:pinned
-
-      - name: Install Latest Tools (always fresh)
-        run: task setup:latest
-
-      - name: Build
-        run: task build
-
-      - name: Run Tests with Race Detection (Unix)
-        if: runner.os != 'Windows'
-        run: task test:race
-
-      - name: Run Tests (Windows - no race detector)
-        if: runner.os == 'Windows'
-        run: task test
+    uses: ./.github/workflows/reusable-test-matrix.yml
+    with:
+      os: ${{ matrix.os }}
 
   # ═══════════════════════════════════════════════════════════════════
   # BUILD TAG VERIFICATION (Main + Releases only)
@@ -372,84 +304,18 @@ jobs:
 
   # ═══════════════════════════════════════════════════════════════════
   # CONFORMANCE GATE (CKSPEC-ENF-009)
-  # Verifies conformance against the LATEST published ckeletin spec.
-  # Runs on the release path (tags) to GATE releases, and weekly to DETECT
-  # drift (opening an issue). NOT on pull_request — an external spec release
-  # must never break an unrelated PR. The spec mandates only the property
-  # ("continuously verify + block release on non-conformance"); CI is this
-  # project's chosen mechanism.
+  # Release gate: a tag cannot release while the project drifts from the latest
+  # published ckeletin spec. Weekly drift detection + on-demand verification
+  # live in conformance.yml (decoupled from the matrix). NOT on pull_request —
+  # an external spec release must never break an unrelated PR. Steps live in
+  # reusable-conformance.yml (SSOT), shared with conformance.yml.
   # ═══════════════════════════════════════════════════════════════════
   conformance:
     name: CKSPEC Conformance
-    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
+    if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: read
-      issues: write # open a drift issue on scheduled failure
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
-        with:
-          go-version-file: '.go-version' # SSOT for Go version
-          cache-dependency-path: 'go.sum'
-
-      - name: Cache Task Binary
-        id: cache-task
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
-        with:
-          path: ~/.local/bin/task
-          key: ${{ runner.os }}-task-${{ env.TASK_VERSION }}
-
-      - name: Install Task
-        if: steps.cache-task.outputs.cache-hit != 'true'
-        run: |
-          INSTALL_DIR="$HOME/.local/bin"
-          mkdir -p "$INSTALL_DIR"
-          curl -sL "https://taskfile.dev/install.sh" | sh -s -- -b "$INSTALL_DIR" v${{ env.TASK_VERSION }}
-        shell: bash
-
-      - name: Add tools to PATH
-        run: |
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          echo "$HOME/go/bin" >> "$GITHUB_PATH"
-
-      - name: Cache Dev Tools (pinned versions)
-        id: cache-devtools
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
-        with:
-          path: ~/go/bin
-          key: ${{ runner.os }}-devtools-${{ hashFiles('.go-version', '.ckeletin/Taskfile.yml') }}-${{ env.PINNED_TOOLS_VERSION }}
-
-      - name: Install Pinned Tools
-        if: steps.cache-devtools.outputs.cache-hit != 'true'
-        run: task setup:pinned
-
-      - name: Install Latest Tools
-        run: task setup:latest
-
-      - name: Install semgrep
-        run: pip3 install --user semgrep # SAST tool the conformance violation tests (ENF-006) invoke
-
-      - name: Run CKSPEC conformance against the latest spec (ENF-009 gate)
-        run: task conform
-
-      - name: Open drift issue (scheduled runs only)
-        if: failure() && github.event_name == 'schedule'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TITLE="Conformance drift: project no longer conforms to the latest ckeletin spec"
-          # Only open an issue if one is not already open (avoid weekly duplicates).
-          OPEN=$(gh issue list --state open --search "$TITLE" --json number --jq 'length')
-          if [ "$OPEN" = "0" ]; then
-            RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-            gh issue create --title "$TITLE" \
-              --body "The weekly CKSPEC conformance check failed — this project has drifted from the latest published spec (peiman/ckeletin). Run \`task conform\` locally and reconcile conformance-mapping.yaml. Run log: $RUN_URL"
-          fi
+    uses: ./.github/workflows/reusable-conformance.yml
 
   # ═══════════════════════════════════════════════════════════════════
   # RELEASE (Tags only - requires test-matrix + build + conformance to pass)

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,52 @@
+name: CKSPEC Conformance
+
+# Verifies conformance against the latest published ckeletin spec
+# (peiman/ckeletin). Runs weekly to DETECT drift (opening an issue) and on
+# demand via workflow_dispatch. Decoupled from the test matrix, so conformance
+# can be verified in ~2 minutes without spinning up cross-platform runners.
+#
+# The RELEASE gate (CKSPEC-ENF-009) lives in ci.yml, which calls the same
+# reusable check on tags. This workflow is NOT triggered on pull_request — an
+# external spec release must never break an unrelated PR.
+on:
+  schedule:
+    # Weekly on Sunday 01:00 UTC. Staggered an hour after ci.yml's Sunday build
+    # (00:00) so the two weekly runs don't contend for runners.
+    - cron: '0 1 * * 0'
+  workflow_dispatch: {}
+
+permissions: {}
+
+concurrency:
+  group: conformance-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  conformance:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/reusable-conformance.yml
+
+  drift-issue:
+    name: Open drift issue (scheduled failure)
+    needs: [conformance]
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write  # open a drift issue on scheduled failure
+    steps:
+      - name: Open drift issue (deduplicated)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: "Conformance drift: project no longer conforms to the latest ckeletin spec"
+        run: |
+          # No checkout in this job, so pass the repo explicitly to gh.
+          # Scope the dedup search to the title field to avoid fuzzy body/comment matches.
+          OPEN=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --search "in:title $TITLE" --json number --jq 'length')
+          if [ "$OPEN" = "0" ]; then
+            RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$TITLE" \
+              --body "The weekly CKSPEC conformance check failed — this project has drifted from the latest published spec (peiman/ckeletin). Run \`task conform\` locally and reconcile conformance-mapping.yaml. Run log: $RUN_URL"
+          fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,74 @@
+name: Nightly Cross-Platform Tests
+
+# Runs the full ubuntu/macOS/windows test matrix nightly, but ONLY when commits
+# landed since the last run — no point spinning up three runners on an idle
+# night. Catches platform-specific breakage within ~24h (cheap to bisect to the
+# day's merges) instead of at release time.
+#
+# The Sunday run is UNCONDITIONAL (a weekly floor) so environment drift with no
+# code change — a macOS runner-image bump, a Go patch regression — is still
+# caught at least weekly. workflow_dispatch also runs unconditionally.
+#
+# The matrix also GATES releases via ci.yml (on tags); this workflow is the
+# early-warning net between releases.
+on:
+  schedule:
+    - cron: '0 3 * * 1-6'  # Mon–Sat at 03:00 UTC — runs only if commits landed
+    - cron: '0 3 * * 0'    # Sunday at 03:00 UTC — runs unconditionally (env-drift floor)
+  workflow_dispatch: {}
+
+permissions: {}
+
+concurrency:
+  group: nightly-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  changes:
+    name: Check for changes since last run
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      has_changes: ${{ steps.check.outputs.has_changes }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 50  # enough history to inspect the last day of commits
+
+      - name: Check for recent commits
+        id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          SCHEDULE: ${{ github.event.schedule }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "Manual dispatch — running the matrix regardless."
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          elif [ "$SCHEDULE" = "0 3 * * 0" ]; then
+            echo "Weekly Sunday run — running the matrix unconditionally (env-drift floor)."
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          elif [ -n "$(git log --since='25 hours ago' --pretty=oneline)" ]; then
+            echo "Commits landed in the last 25h — running the matrix."
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No commits in the last 25h — skipping the nightly matrix."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
+
+  test-matrix:
+    name: Test
+    needs: [changes]
+    if: needs.changes.outputs.has_changes == 'true'
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    uses: ./.github/workflows/reusable-test-matrix.yml
+    with:
+      os: ${{ matrix.os }}

--- a/.github/workflows/reusable-conformance.yml
+++ b/.github/workflows/reusable-conformance.yml
@@ -1,0 +1,73 @@
+name: Reusable Conformance Check
+
+# Reusable CKSPEC conformance check (CKSPEC-ENF-009): verifies the project
+# conforms to the LATEST published ckeletin spec (peiman/ckeletin). Called by:
+#   - ci.yml          → on tags, to GATE releases (release: needs [conformance])
+#   - conformance.yml → weekly (drift detection) and on workflow_dispatch
+# Single source of truth for the conformance check so the release gate and the
+# drift detector run exactly the same steps.
+on:
+  workflow_call: {}
+
+permissions: {}
+
+env:
+  TASK_VERSION: '3.39.2'        # keep in sync with ci.yml
+  PINNED_TOOLS_VERSION: 'v1'    # keep in sync with ci.yml (cache-busting)
+
+jobs:
+  conformance:
+    name: CKSPEC Conformance
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: '.go-version'  # SSOT for Go version
+          cache-dependency-path: 'go.sum'
+
+      - name: Cache Task Binary
+        id: cache-task
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.local/bin/task
+          key: ${{ runner.os }}-task-${{ env.TASK_VERSION }}
+
+      - name: Install Task
+        if: steps.cache-task.outputs.cache-hit != 'true'
+        run: |
+          INSTALL_DIR="$HOME/.local/bin"
+          mkdir -p "$INSTALL_DIR"
+          curl -sL "https://taskfile.dev/install.sh" | sh -s -- -b "$INSTALL_DIR" v${{ env.TASK_VERSION }}
+        shell: bash
+
+      - name: Add tools to PATH
+        run: |
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+
+      - name: Cache Dev Tools (pinned versions)
+        id: cache-devtools
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/go/bin
+          key: ${{ runner.os }}-devtools-${{ hashFiles('.go-version', '.ckeletin/Taskfile.yml') }}-${{ env.PINNED_TOOLS_VERSION }}
+
+      - name: Install Pinned Tools
+        if: steps.cache-devtools.outputs.cache-hit != 'true'
+        run: task setup:pinned
+
+      - name: Install Latest Tools
+        run: task setup:latest
+
+      - name: Install semgrep
+        run: pip3 install --user semgrep  # SAST tool the conformance violation tests (ENF-006) invoke
+
+      - name: Run CKSPEC conformance against the latest spec (ENF-009 gate)
+        run: task conform

--- a/.github/workflows/reusable-test-matrix.yml
+++ b/.github/workflows/reusable-test-matrix.yml
@@ -1,0 +1,99 @@
+name: Reusable Test Matrix
+
+# Reusable single-OS test run (build + tests). Called by:
+#   - ci.yml      → on tags only (the release gate)
+#   - nightly.yml → nightly (change-guarded) + weekly floor + on demand
+# Defined once so the matrix steps live in a single place (SSOT). The caller
+# fans out over operating systems via its own `strategy.matrix` and passes the
+# OS in as `os`.
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: Runner OS to test on (e.g. ubuntu-latest, macos-latest, windows-latest)
+        required: true
+        type: string
+
+permissions: {}
+
+env:
+  TASK_VERSION: '3.39.2'        # keep in sync with ci.yml
+  PINNED_TOOLS_VERSION: 'v1'    # keep in sync with ci.yml (cache-busting)
+
+jobs:
+  test:
+    name: ${{ inputs.os }}
+    runs-on: ${{ inputs.os }}
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: '.go-version'  # SSOT for Go version
+          cache-dependency-path: 'go.sum'
+
+      - name: Download Dependencies
+        run: go mod download
+
+      - name: Install Task (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          INSTALL_DIR="$HOME/.local/bin"
+          mkdir -p "$INSTALL_DIR"
+          curl -sL https://taskfile.dev/install.sh | sh -s -- -b "$INSTALL_DIR" v${{ env.TASK_VERSION }}
+          echo "$INSTALL_DIR" >> "$GITHUB_PATH"
+        shell: bash
+
+      - name: Install Task (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          $INSTALL_DIR = "$env:USERPROFILE\.local\bin"
+          New-Item -ItemType Directory -Force -Path $INSTALL_DIR
+          $TASK_URL = "https://github.com/go-task/task/releases/download/v${{ env.TASK_VERSION }}/task_windows_amd64.zip"
+          Invoke-WebRequest -Uri $TASK_URL -OutFile task.zip
+          Expand-Archive -Path task.zip -DestinationPath $INSTALL_DIR -Force
+          Remove-Item task.zip
+          echo "$INSTALL_DIR" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        shell: pwsh
+
+      - name: Verify Task Installation
+        run: task --version
+
+      - name: Cache Dev Tools (pinned versions)
+        id: cache-devtools
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/go/bin
+          key: ${{ runner.os }}-devtools-${{ hashFiles('.go-version', '.ckeletin/Taskfile.yml') }}-${{ env.PINNED_TOOLS_VERSION }}
+
+      - name: Add Go bin to PATH (Unix)
+        if: runner.os != 'Windows'
+        run: echo "$HOME/go/bin" >> "$GITHUB_PATH"
+
+      - name: Add Go bin to PATH (Windows)
+        if: runner.os == 'Windows'
+        run: echo "$env:USERPROFILE\go\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        shell: pwsh
+
+      - name: Install Pinned Tools
+        if: steps.cache-devtools.outputs.cache-hit != 'true'
+        run: task setup:pinned
+
+      - name: Install Latest Tools (always fresh)
+        run: task setup:latest
+
+      - name: Build
+        run: task build
+
+      - name: Run Tests with Race Detection (Unix)
+        if: runner.os != 'Windows'
+        run: task test:race
+
+      - name: Run Tests (Windows - no race detector)
+        if: runner.os == 'Windows'
+        run: task test


### PR DESCRIPTION
Decouples the expensive cross-platform matrix and the CKSPEC conformance check so each runs at the right cadence — while keeping the **CKSPEC-ENF-009 release gate identical in strength**.

## Why
- The conformance check could only be verified by dispatching `ci.yml`, which dragged the full ubuntu/macOS/windows matrix (~20 min for a 2-min check).
- The full matrix ran on **every merge to main** — expensive, and late feedback either way.

## What
- **`reusable-test-matrix.yml`** + **`reusable-conformance.yml`** (`workflow_call`): matrix and conformance steps defined **once** (SSOT), called from multiple workflows.
- **`nightly.yml`**: runs the matrix nightly **only when commits landed in the last 25h** (change-guard), with an **unconditional Sunday floor** so environment drift (runner-image / Go-toolchain regressions) is caught weekly even with no code change. Dispatchable on demand.
- **`conformance.yml`**: weekly drift detection (deduped issue) + on-demand dispatch — verifiable in **~2 min, no matrix**.
- **`ci.yml`**: inline test-matrix + conformance jobs → reusable-workflow calls gated to **tags**. `release` still `needs: [test-matrix, build, conformance]`, so a tag cannot release while non-conformant or while the matrix fails. Per-merge matrix dropped (PRs keep the fast Linux check; nightly covers between releases).

## Cadence after this change
| Event | Matrix | Conformance | Full `task check` (license) |
|---|---|---|---|
| PR | – | – | fast Linux check |
| push → main | – | – | full |
| **tag (release)** | **✓ gate** | **✓ gate** | full |
| nightly (Mon–Sat) | ✓ if commits | – | – |
| Sunday | ✓ always | ✓ (weekly) | ✓ (weekly) |
| dispatch | `nightly.yml` | `conformance.yml` | `ci.yml` |

## Verification
- **actionlint** clean on all 5 files (also re-run by `lint-workflows` CI).
- **Adversarial review** (5 lenses) → APPROVE on release-gate integrity ("no bypass paths found") and reusable-workflow semantics; its low/nit findings folded in (weekly env-drift floor, `in:title` dedup, comment/cron fixes).
- Runtime of the new dispatch/schedule workflows will be confirmed post-merge via `gh workflow run conformance.yml` / `nightly.yml` on `main` (new `workflow_dispatch` workflows can't be dispatched until they're on the default branch).