### PR TITLE
fix(conform): parse conformance mapping with yq + reject invalid YAML

### DIFF
--- a/.ckeletin/Taskfile.yml
+++ b/.ckeletin/Taskfile.yml
@@ -469,7 +469,7 @@ tasks:
         task --version || echo "  ❌ Task not found"
         echo ""
         echo "Development Tools:"
-        for tool in goimports golangci-lint gotestsum govulncheck lefthook go-mod-outdated go-licenses lichen gocovmerge; do
+        for tool in goimports golangci-lint gotestsum govulncheck lefthook go-mod-outdated go-licenses lichen gocovmerge yq; do
           if command -v "$tool" > /dev/null 2>&1; then
             echo "  $tool: ✅ installed"
           else

--- a/.ckeletin/scripts/conform.sh
+++ b/.ckeletin/scripts/conform.sh
@@ -16,46 +16,56 @@ FEEDBACK_FILE=$(mktemp)
 WARNING_FILE=$(mktemp)
 trap 'rm -f "$FAIL_FILE" "$FEEDBACK_FILE" "$WARNING_FILE"' EXIT
 
-# ── Parse helpers (YAML subset — no external deps) ──────────────
+# ── Require yq, and fail fast if the mapping is not valid YAML ───
+# conform.sh parses the mapping with yq (one consistent YAML parser). An
+# unparseable mapping — e.g. a check string with an invalid backslash escape —
+# must fail the build, and therefore the release gate (CKSPEC-ENF-009), rather
+# than be silently tolerated by a lenient text scan. This gate runs first so a
+# broken mapping exits before any checks (including the conformance test suite),
+# which keeps it cheap and recursion-free.
+if ! command -v yq >/dev/null 2>&1; then
+    echo "FAILED — 'yq' is required to parse $MAPPING_FILE but was not found on PATH."
+    echo "  Install yq (https://github.com/mikefarah/yq) and re-run."
+    exit 1
+fi
+if ! yq '.' "$MAPPING_FILE" >/dev/null 2>&1; then
+    echo "FAILED — $MAPPING_FILE is not valid YAML (yq could not parse it)."
+    echo "  Run 'yq . $MAPPING_FILE' to see the parse error."
+    echo "  Tip: a shell command containing regex backslashes must be written as a"
+    echo "       literal block scalar (- |-) so it is taken verbatim — see the file header."
+    exit 1
+fi
+
+# ── Parse helpers (all reads go through yq — one consistent parser) ──
+# Requirement IDs contain hyphens, so paths use strenv() to pass the id/field
+# in as data rather than interpolating untrusted text into the yq expression.
 
 get_spec_version() {
-    grep '^spec_version:' "$MAPPING_FILE" | head -1 | sed 's/spec_version: *"\(.*\)"/\1/'
+    yq '.spec_version // ""' "$MAPPING_FILE"
 }
 
 get_requirement_ids() {
-    grep '^  CKSPEC-' "$MAPPING_FILE" | sed 's/^ *\(CKSPEC-[A-Z]*-[0-9]*\):.*/\1/'
+    yq '.requirements | keys | .[]' "$MAPPING_FILE"
 }
 
-# Get a scalar field from a requirement block
+# Get a scalar field (title, status, enforcement_level) from a requirement.
 get_field() {
     local req_id="$1" field="$2"
-    awk -v req="$req_id" -v field="$field" '
-        /^  [A-Z]/ && $0 ~ req":" { found=1; next }
-        found && /^  [A-Z]/ { found=0 }
-        found && $0 ~ "^    " field ":" {
-            line=$0
-            sub(/^[^:]*: */, "", line)
-            gsub(/^ *"?/, "", line); gsub(/"? *$/, "", line)
-            if (line != "" && line != ">") print line
-            exit
-        }
-    ' "$MAPPING_FILE"
+    req="$req_id" field="$field" \
+        yq '.requirements[strenv(req)][strenv(field)] // ""' "$MAPPING_FILE"
 }
 
-# Get array items (checks or violation_tests)
+# Get array items (checks or violation_tests); empty/missing → no output.
 get_array_items() {
     local req_id="$1" field="$2"
-    awk -v req="$req_id" -v field="$field" '
-        /^  [A-Z]/ && $0 ~ req":" { found=1; next }
-        found && /^  [A-Z]/ { found=0 }
-        found && $0 ~ "^    " field ":" { in_array=1; next }
-        in_array && /^    [a-zA-Z_]/ { in_array=0; next }
-        in_array && /^      - / {
-            line=$0
-            sub(/^ *- *"?/, "", line); sub(/"? *$/, "", line)
-            if (line != "") print line
-        }
-    ' "$MAPPING_FILE"
+    req="$req_id" field="$field" \
+        yq '(.requirements[strenv(req)][strenv(field)] // [])[]' "$MAPPING_FILE"
+}
+
+# Print "true" if a requirement declares a violation_evidence block, else "false".
+has_violation_evidence() {
+    local req_id="$1"
+    req="$req_id" yq '.requirements[strenv(req)] | has("violation_evidence")' "$MAPPING_FILE"
 }
 
 # ── Main ────────────────────────────────────────────────────────
@@ -159,7 +169,7 @@ echo ""
 
 # ── ENF-008 drift guard: machine-derivable facts in evidence must match reality.
 # (A hand-typed count in prose silently rots — e.g. "35" after a 36th requirement.)
-DRIFT=$(grep -oE 'all [0-9]+ requirement' "$MAPPING_FILE" | grep -oE '[0-9]+' | head -1 || true)
+DRIFT=$(yq '.requirements[].evidence // ""' "$MAPPING_FILE" | grep -oE 'all [0-9]+ requirement' | grep -oE '[0-9]+' | head -1 || true)
 if [[ -n "$DRIFT" && "$DRIFT" != "$TOTAL" ]]; then
     echo "evidence drift: prose claims '$DRIFT requirement IDs' but $TOTAL are mapped (ENF-008)" >> "$FAIL_FILE"
 fi
@@ -192,13 +202,10 @@ for req_id in $REQ_IDS; do
     if [[ "$status" == "met" ]]; then
         a_checks=$(get_array_items "$req_id" "checks")
         a_vtests=$(get_array_items "$req_id" "violation_tests")
-        a_vevid=$(awk -v req="$req_id" '
-            /^  [A-Z]/ && $0 ~ req":" { f=1; next }
-            f && /^  [A-Z]/ { f=0 }
-            f && /violation_evidence:/ { print "y"; exit }' "$MAPPING_FILE")
+        a_vevid=$(has_violation_evidence "$req_id")
         if [[ -n "$a_checks" || -n "$a_vtests" ]]; then
             ENF008_AUTOMATED=$((ENF008_AUTOMATED + 1))
-        elif [[ "$enforcement" == "honor-system" && -n "$a_vevid" ]]; then
+        elif [[ "$enforcement" == "honor-system" && "$a_vevid" == "true" ]]; then
             ENF008_ANALYSIS=$((ENF008_ANALYSIS + 1))
         else
             echo "$req_id ($title): met but unanchored — add a check/violation_test, or declare honor-system + violation_evidence (ENF-008)" >> "$FAIL_FILE"
@@ -209,15 +216,10 @@ for req_id in $REQ_IDS; do
     # Accepts either violation_tests OR violation_evidence (spec v0.4.0+)
     if [[ "$enforcement" != "honor-system" && "$enforcement" != "" ]]; then
         vtests=$(get_array_items "$req_id" "violation_tests")
-        # Check if violation_evidence exists in this requirement's block
-        # (multi-line field, so get_field may not capture it — use grep)
-        vevidence=$(awk -v req="$req_id" '
-            /^  [A-Z]/ && $0 ~ req":" { found=1; next }
-            found && /^  [A-Z]/ { found=0 }
-            found && /violation_evidence:/ { print "yes"; exit }
-        ' "$MAPPING_FILE")
+        # "true" if this requirement declares a violation_evidence block.
+        vevidence=$(has_violation_evidence "$req_id")
 
-        if [[ -z "$vtests" && -z "$vevidence" ]]; then
+        if [[ -z "$vtests" && "$vevidence" != "true" ]]; then
             echo "$req_id: claims $enforcement but has no violation test or evidence" >> "$FEEDBACK_FILE"
         elif [[ -n "$vtests" ]]; then
             echo "$vtests" | while IFS= read -r vt; do
@@ -260,9 +262,9 @@ done
 
 # ── Collect results ──────────────────────────────────────────────
 
-MET=$(grep -c 'status: met' "$MAPPING_FILE" || true)
-DEFERRED=$(grep -c 'status: deferred' "$MAPPING_FILE" || true)
-PARTIAL=$(grep -c 'status: partial' "$MAPPING_FILE" || true)
+MET=$(yq '[.requirements[] | select(.status == "met")] | length' "$MAPPING_FILE")
+DEFERRED=$(yq '[.requirements[] | select(.status == "deferred")] | length' "$MAPPING_FILE")
+PARTIAL=$(yq '[.requirements[] | select(.status == "partial")] | length' "$MAPPING_FILE")
 FAILED_CHECKS=0
 if [[ -s "$FAIL_FILE" ]]; then
     FAILED_CHECKS=$(wc -l < "$FAIL_FILE" | tr -d ' ')

--- a/.ckeletin/scripts/conform.sh
+++ b/.ckeletin/scripts/conform.sh
@@ -28,6 +28,14 @@ if ! command -v yq >/dev/null 2>&1; then
     echo "  Install yq (https://github.com/mikefarah/yq) and re-run."
     exit 1
 fi
+# Must be mikefarah/yq v4 (Go): the parser below uses strenv(), which the Python
+# yq (kislyuk) lacks. Probe the capability so a wrong variant fails here with a
+# clear message instead of a cryptic "unknown function strenv" mid-run.
+if ! printf 'a: 1\n' | probe=x yq '.a = strenv(probe)' >/dev/null 2>&1; then
+    echo "FAILED — the 'yq' on PATH is not mikefarah/yq v4 (strenv unsupported)."
+    echo "  conform.sh needs mikefarah/yq: https://github.com/mikefarah/yq"
+    exit 1
+fi
 if ! yq '.' "$MAPPING_FILE" >/dev/null 2>&1; then
     echo "FAILED — $MAPPING_FILE is not valid YAML (yq could not parse it)."
     echo "  Run 'yq . $MAPPING_FILE' to see the parse error."
@@ -81,7 +89,7 @@ echo "Mapping file: $MAPPING_FILE"
 echo ""
 
 REQ_IDS=$(get_requirement_ids)
-TOTAL=$(echo "$REQ_IDS" | wc -l | tr -d ' ')
+TOTAL=$(yq '.requirements | keys | length' "$MAPPING_FILE")
 
 echo "Requirements mapped: $TOTAL"
 echo ""

--- a/.ckeletin/scripts/install_tools.sh
+++ b/.ckeletin/scripts/install_tools.sh
@@ -37,6 +37,7 @@ install_tool "govulncheck" "golang.org/x/vuln/cmd/govulncheck@latest"
 install_tool "gotestsum" "gotest.tools/gotestsum@latest"
 install_tool "golangci-lint" "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.3.0"
 install_tool "go-mod-outdated" "github.com/psampaz/go-mod-outdated@latest"
+install_tool "yq" "github.com/mikefarah/yq/v4@latest"  # mikefarah/yq (Go): conform.sh parses the conformance mapping with it
 
 # Optional: lefthook (may fail due to network/version issues, not critical)
 if ! command_exists "lefthook"; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ concurrency:
 env:
   # GO_VERSION is read from .go-version file (SSOT)
   # Use setup-go's go-version-file parameter instead of hardcoding
-  YQ_VERSION: '4.34.1'       # Define yq version here
   TASK_VERSION: '3.39.2'     # Define Task version here
   # Pinned tool versions for cache key (must match .ckeletin/Taskfile.yml)
   PINNED_TOOLS_VERSION: 'v1'  # Bump to invalidate cache when tool versions change

--- a/.github/workflows/reusable-conformance.yml
+++ b/.github/workflows/reusable-conformance.yml
@@ -14,6 +14,7 @@ permissions: {}
 env:
   TASK_VERSION: '3.39.2'        # keep in sync with ci.yml
   PINNED_TOOLS_VERSION: 'v1'    # keep in sync with ci.yml (cache-busting)
+  YQ_VERSION: '4.44.6'          # conform.sh parses conformance-mapping.yaml with yq
 
 jobs:
   conformance:
@@ -68,6 +69,15 @@ jobs:
 
       - name: Install semgrep
         run: pip3 install --user semgrep  # SAST tool the conformance violation tests (ENF-006) invoke
+
+      - name: Install yq
+        run: |
+          INSTALL_DIR="$HOME/.local/bin"
+          mkdir -p "$INSTALL_DIR"
+          curl -sSfL "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64" -o "$INSTALL_DIR/yq"
+          chmod +x "$INSTALL_DIR/yq"
+          yq --version
+        shell: bash
 
       - name: Run CKSPEC conformance against the latest spec (ENF-009 gate)
         run: task conform

--- a/conformance-mapping.yaml
+++ b/conformance-mapping.yaml
@@ -1,6 +1,17 @@
 # Conformance mapping: maps automated checks to CKSPEC requirement IDs.
 # Used by `task conform` to generate the conformance report.
 # Format agreed between ckeletin-go and ckeletin-rust architects.
+#
+# This file MUST be valid YAML — `conform.sh` parses it with `yq` and fails the
+# build (and the release gate) if it does not parse. A `checks:` entry is a shell
+# command. When a command contains regex backslashes or other YAML-special
+# characters, write it as a literal block scalar so it is taken verbatim — no
+# escaping:
+#     checks:
+#       - |-
+#         grep -qE 'foo\.bar' some/file
+# Simple commands with no special characters may stay as plain double-quoted
+# one-liners (e.g. "task validate:layering").
 
 spec_version: "0.6.0"
 
@@ -382,7 +393,8 @@ requirements:
       Debug level ensures shadow logs reach file logger without
       polluting console. Verified by unit tests.
     checks:
-      - "grep -qE 'log\.Debug' internal/ui/renderer.go"
+      - |-
+        grep -qE 'log\.Debug' internal/ui/renderer.go
     violation_tests: []
     violation_evidence: >
       Removing the shadow log.Debug from the renderer fails the grep
@@ -461,7 +473,8 @@ requirements:
       duplicated. .cursorrules and copilot-instructions.md also
       reference AGENTS.md.
     checks:
-      - "grep -qE 'AGENTS\.md' CLAUDE.md"
+      - |-
+        grep -qE 'AGENTS\.md' CLAUDE.md
     violation_tests: []
     violation_evidence: >
       If a provider guide stops referencing AGENTS.md, the grep check
@@ -533,7 +546,8 @@ requirements:
     enforcement_level: script
     evidence: "All dates use YYYY-MM-DD format."
     checks:
-      - "grep -qE '^## \[.+\] - [0-9]{4}-[0-9]{2}-[0-9]{2}' CHANGELOG.md"
+      - |-
+        grep -qE '^## \[.+\] - [0-9]{4}-[0-9]{2}-[0-9]{2}' CHANGELOG.md
     violation_tests: []
     violation_evidence: >
       A non-ISO-8601 release date fails the date-format grep check.
@@ -546,7 +560,8 @@ requirements:
       CHANGELOG.md states adherence to SemVer. Version numbers follow
       MAJOR.MINOR.PATCH throughout.
     checks:
-      - "grep -qE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md"
+      - |-
+        grep -qE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md
     violation_tests: []
     violation_evidence: >
       A non-SemVer version header fails the grep check.
@@ -557,7 +572,8 @@ requirements:
     enforcement_level: script
     evidence: "[Unreleased] section present at top of CHANGELOG.md."
     checks:
-      - "grep -qE '^## \[Unreleased\]' CHANGELOG.md"
+      - |-
+        grep -qE '^## \[Unreleased\]' CHANGELOG.md
     violation_tests: []
     violation_evidence: >
       Removing the Unreleased section fails the grep check.
@@ -585,7 +601,8 @@ requirements:
       Reference-style comparison links at bottom of CHANGELOG.md for
       all versions.
     checks:
-      - "grep -qE '^\[.+\]: https?://.+/compare/' CHANGELOG.md"
+      - |-
+        grep -qE '^\[.+\]: https?://.+/compare/' CHANGELOG.md
     violation_tests: []
     violation_evidence: >
       Removing the reference-style compare links fails the grep check.

--- a/test/conformance/violation_test.go
+++ b/test/conformance/violation_test.go
@@ -540,3 +540,46 @@ func TestViolation_ENF007_FeedbackSignalsProduced(t *testing.T) {
 	assert.Contains(t, string(script), "Feedback signals",
 		"conform.sh should report feedback signals in output")
 }
+
+// ---------------------------------------------------------------------------
+// Conformance tooling integrity: the mapping MUST be valid YAML.
+// Enforcement: conform.sh parses conformance-mapping.yaml with yq and fails the
+// build — and therefore the release gate (CKSPEC-ENF-009) — if it does not parse.
+// This guards the conform.sh parser itself (not a spec requirement): before this
+// gate existed, a lenient text scan silently tolerated an invalid-YAML mapping
+// (e.g. a check string with an unescaped regex backslash), so a broken mapping
+// could pass conformance. Violation: an unparseable mapping must be rejected.
+// ---------------------------------------------------------------------------
+
+func TestViolation_ConformMapping_InvalidYAMLRejected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("violation tests modify the source tree")
+	}
+
+	root := projectRoot(t)
+	mappingPath := filepath.Join(root, "conformance-mapping.yaml")
+
+	original, err := os.ReadFile(mappingPath)
+	require.NoError(t, err)
+
+	// Append a top-level scalar with an invalid YAML escape (\q). This is the
+	// same defect class as a regex check written as a plain double-quoted string
+	// ("...\.foo"): valid to a text scan, rejected by any real YAML parser.
+	violated := string(original) + "\nbroken_invalid_yaml: \"x\\q\"\n"
+	require.NoError(t, os.WriteFile(mappingPath, []byte(violated), 0644))
+	defer func() {
+		// Restore the original mapping regardless of assertion outcome.
+		os.WriteFile(mappingPath, original, 0644)
+	}()
+
+	output, exitCode := runCheck(t, "bash", scriptPath(t, "conform.sh"))
+
+	assert.NotEqual(t, 0, exitCode,
+		"conform.sh must fail when the mapping is not valid YAML\nOutput: %s", output)
+	assert.Contains(t, output, "not valid YAML",
+		"conform.sh must report the YAML parse failure\nOutput: %s", output)
+	// The gate must run before the check loop so a broken mapping exits cheaply
+	// and never re-invokes the conformance suite (recursion-free, like ENF-005).
+	assert.NotContains(t, output, "Running checks",
+		"the YAML gate must fail fast, before running any checks\nOutput: %s", output)
+}

--- a/test/conformance/violation_test.go
+++ b/test/conformance/violation_test.go
@@ -583,3 +583,39 @@ func TestViolation_ConformMapping_InvalidYAMLRejected(t *testing.T) {
 	assert.NotContains(t, output, "Running checks",
 		"the YAML gate must fail fast, before running any checks\nOutput: %s", output)
 }
+
+// ---------------------------------------------------------------------------
+// Conformance tooling integrity: yq must be mikefarah/yq v4 (Go).
+// Enforcement: conform.sh probes strenv() — a mikefarah-only function it relies
+// on for safe field access — and fails with a clear message if the yq on PATH is
+// the unrelated Python yq (kislyuk), instead of a cryptic mid-run strenv error.
+// Violation: a non-mikefarah yq earlier on PATH must be rejected up front.
+// ---------------------------------------------------------------------------
+
+func TestViolation_ConformMapping_NonMikefarahYqRejected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("violation tests shell out to conform.sh")
+	}
+
+	root := projectRoot(t)
+
+	// A stand-in "yq" that parses ('.' succeeds) but lacks strenv (any other
+	// invocation fails) — the observable behaviour of the Python yq for our use.
+	fakeBin := t.TempDir()
+	fakeYq := "#!/bin/sh\n" +
+		"if [ \"$1\" = \".\" ]; then exit 0; fi\n" +
+		"echo 'yq (python stand-in): unknown function strenv' >&2\nexit 1\n"
+	require.NoError(t, os.WriteFile(filepath.Join(fakeBin, "yq"), []byte(fakeYq), 0755))
+
+	cmd := exec.Command("bash", scriptPath(t, "conform.sh"))
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(), "PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	out, err := cmd.CombinedOutput()
+	output := string(out)
+
+	require.Error(t, err, "conform.sh must fail when yq is not mikefarah/yq\nOutput: %s", output)
+	assert.Contains(t, output, "not mikefarah/yq",
+		"conform.sh must report the wrong yq variant clearly\nOutput: %s", output)
+	assert.NotContains(t, output, "Running checks",
+		"the yq-variant gate must fail fast, before running any checks\nOutput: %s", output)
+}


### PR DESCRIPTION
## Problem

`conformance-mapping.yaml` was **not valid YAML**. Six `checks:` entries were double-quoted scalars containing regex backslashes (e.g. `"grep -qE 'log\.Debug' ..."`), and `\.` is an invalid escape in a double-quoted YAML scalar. `conform.sh` — the **CKSPEC-ENF-009 release gate** — only tolerated this because it parsed the mapping with a lenient awk/grep text scan. Any real YAML parser (`yq`) rejected the file.

Consequences:
- The mapping couldn't be machine-read (a prerequisite for publishing a conformance report — Increment B2/B3).
- A malformed mapping could pass conformance silently: the gate was blind to its own data file being broken.

**Proof (before):** `yq . conformance-mapping.yaml` → parse error, yet `task conform` → PASSED.

## Fix — one consistent parser, fail closed on bad data

**`7d83746` — core**
- Convert the 6 regex checks to literal block scalars (`- |-`) so the shell command is taken verbatim, no escaping. Convention documented in the file header.
- Rewrite `conform.sh` extraction (spec version, requirement ids, scalar fields, array items, `violation_evidence` presence, met/partial/deferred tallies, ENF-008 drift guard) to use **`yq`**. Ids/fields pass through `strenv()` so they are data, never interpolated into the expression.
- Add a yq-availability check and an **early YAML-parse gate** that fails the build (and the release gate) **before any checks run** — fast and recursion-free (it exits before the `go test -tags conformance` check).
- Install pinned `yq` in the CI conformance job; drop the now-unused `YQ_VERSION` from `ci.yml`.

**`9789ee3` — hardening (from adversarial review)**
- Probe `strenv()` up front so a non-mikefarah `yq` (the unrelated Python `kislyuk/yq`) fails with a clear *"not mikefarah/yq v4"* message instead of a cryptic mid-run error.
- Count requirements via `yq '.requirements | keys | length'` (the old `echo | wc -l` reported 1 for an empty map).
- Register `yq` in the dev toolchain (`install_tools.sh` + `task doctor`), since `conform.sh` now hard-requires it.

## Verification
- New `task conform` output is **byte-identical** to the prior run: **38/38 met, 0 partial, 0 deferred, 32 automated + 6 analysis-with-evidence**.
- The gate rejects a broken mapping fast with `"not valid YAML"`; fails **closed** if `yq` is missing or is the wrong variant.
- New violation tests: `TestViolation_ConformMapping_InvalidYAMLRejected`, `TestViolation_ConformMapping_NonMikefarahYqRejected`.
- `task check` green; `actionlint` clean.

## Reviewed
Multi-lens adversarial review (release-gate integrity, shell/yq correctness, YAML equivalence, security, CI): 16 observations raised, **0 material** — all pre-existing non-regressions or fail-closed paths. The cheap, in-scope ones were folded into `9789ee3`.

This is foundation step **B1** of automating the impl→spec conformance flow; B2 (publish a machine-readable report) builds on the now-parseable mapping.