### PR TITLE
feat(conform): publish deterministic machine-readable conformance report

### DIFF
--- a/.ckeletin/scripts/conform.sh
+++ b/.ckeletin/scripts/conform.sh
@@ -189,11 +189,23 @@ if [[ ! -f "$REPORT_FILE" ]]; then
     echo "FAILED — $REPORT_FILE is missing. Run 'task generate:conformance-report' and commit it."
     exit 1
 fi
-if ! diff <(bash "$GEN_SCRIPT" "$MAPPING_FILE") "$REPORT_FILE" >/dev/null 2>&1; then
+# Generate into a temp file and check the generator's exit code SEPARATELY from
+# the diff, so a broken generator reports "generation failed" (not a misleading
+# "out of sync" whose suggested remediation would overwrite the committed report).
+GEN_TMP=$(mktemp)
+if ! bash "$GEN_SCRIPT" "$MAPPING_FILE" > "$GEN_TMP"; then
+    rm -f "$GEN_TMP"
+    echo "FAILED — could not generate the conformance report from $MAPPING_FILE."
+    echo "  Run 'bash $GEN_SCRIPT $MAPPING_FILE' to see the generator error."
+    exit 1
+fi
+if ! diff "$GEN_TMP" "$REPORT_FILE" >/dev/null 2>&1; then
+    rm -f "$GEN_TMP"
     echo "FAILED — $REPORT_FILE is out of sync with $MAPPING_FILE."
     echo "  Run 'task generate:conformance-report' and commit the result."
     exit 1
 fi
+rm -f "$GEN_TMP"
 echo "Report sync: $REPORT_FILE matches the mapping (PASS)"
 echo ""
 

--- a/.ckeletin/scripts/conform.sh
+++ b/.ckeletin/scripts/conform.sh
@@ -175,6 +175,28 @@ fi
 echo "Completeness: $TOTAL/$TOTAL requirements mapped (ENF-005: PASS)"
 echo ""
 
+# ── Report sync guard: the committed conformance-report.json must match what
+# gen-conformance-report.sh produces from the mapping (mirrors the spec repo's
+# requirements.json sync pattern; P9). A stale report would publish wrong status,
+# so drift fails the build — and the release gate — here, before the checks run
+# (fast, recursion-free), prompting a regenerate. The spec repo aggregates this
+# published report instead of hand-authoring conformance/ckeletin-go.yaml.
+# Runs AFTER the completeness check so a mapping that drops a requirement fails
+# as "unmapped" (ENF-005) rather than as report drift.
+REPORT_FILE="conformance-report.json"
+GEN_SCRIPT=".ckeletin/scripts/gen-conformance-report.sh"
+if [[ ! -f "$REPORT_FILE" ]]; then
+    echo "FAILED — $REPORT_FILE is missing. Run 'task generate:conformance-report' and commit it."
+    exit 1
+fi
+if ! diff <(bash "$GEN_SCRIPT" "$MAPPING_FILE") "$REPORT_FILE" >/dev/null 2>&1; then
+    echo "FAILED — $REPORT_FILE is out of sync with $MAPPING_FILE."
+    echo "  Run 'task generate:conformance-report' and commit the result."
+    exit 1
+fi
+echo "Report sync: $REPORT_FILE matches the mapping (PASS)"
+echo ""
+
 # ── ENF-008 drift guard: machine-derivable facts in evidence must match reality.
 # (A hand-typed count in prose silently rots — e.g. "35" after a 36th requirement.)
 DRIFT=$(yq '.requirements[].evidence // ""' "$MAPPING_FILE" | grep -oE 'all [0-9]+ requirement' | grep -oE '[0-9]+' | head -1 || true)

--- a/.ckeletin/scripts/gen-conformance-report.sh
+++ b/.ckeletin/scripts/gen-conformance-report.sh
@@ -43,4 +43,4 @@ yq -o=json '
   }))
 }
 ' "$MAPPING_FILE" |
-    python3 -c 'import json, sys; json.dump(json.load(sys.stdin), sys.stdout, indent=2, sort_keys=True); sys.stdout.write("\n")'
+    python3 -c 'import json, sys; json.dump(json.load(sys.stdin), sys.stdout, indent=2, sort_keys=True, ensure_ascii=True); sys.stdout.write("\n")'

--- a/.ckeletin/scripts/gen-conformance-report.sh
+++ b/.ckeletin/scripts/gen-conformance-report.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Generate the machine-readable conformance report for ckeletin-go.
+#
+# Emits a DETERMINISTIC JSON projection of conformance-mapping.yaml to stdout:
+# header (implementation, spec_version), summary totals, and per-requirement
+# {status, enforcement_level, evidence, checks, violation_tests,
+# violation_evidence}. The spec repo (peiman/ckeletin) aggregates this published
+# report instead of hand-authoring conformance/ckeletin-go.yaml (CKSPEC SSOT).
+#
+# Determinism: yq extracts the DATA (semantics are YAML-spec-defined, so stable
+# across yq versions) and python3 canonicalizes the FORMATTING (sorted keys,
+# fixed indent). So the committed report is byte-stable regardless of which yq
+# version produced it — which is what makes the `task conform` sync-check
+# reliable in CI (yq 4.44.6) and locally (any mikefarah yq v4).
+#
+# There is intentionally NO timestamp in the output: a volatile field would
+# break the sync-check. The spec-repo aggregator stamps the fetch date.
+#
+# Usage: gen-conformance-report.sh [mapping-file]   (default conformance-mapping.yaml)
+
+set -euo pipefail
+
+MAPPING_FILE="${1:-conformance-mapping.yaml}"
+
+yq -o=json '
+{
+  "implementation": "ckeletin-go",
+  "spec_version": .spec_version,
+  "summary": {
+    "total": (.requirements | length),
+    "met": ([.requirements[] | select(.status == "met")] | length),
+    "partial": ([.requirements[] | select(.status == "partial")] | length),
+    "deferred": ([.requirements[] | select(.status == "deferred")] | length),
+    "passed": (([.requirements[] | select(.status == "met")] | length) == (.requirements | length))
+  },
+  "requirements": (.requirements | map_values({
+    "status": .status,
+    "enforcement_level": .enforcement_level,
+    "evidence": .evidence,
+    "checks": (.checks // []),
+    "violation_tests": (.violation_tests // []),
+    "violation_evidence": .violation_evidence
+  }))
+}
+' "$MAPPING_FILE" |
+    python3 -c 'import json, sys; json.dump(json.load(sys.stdin), sys.stdout, indent=2, sort_keys=True); sys.stdout.write("\n")'

--- a/.ckeletin/scripts/scaffold/helpers.go
+++ b/.ckeletin/scripts/scaffold/helpers.go
@@ -37,11 +37,12 @@ func removePkgDirectory(projectRoot string) error {
 // removeFrameworkOnlyArtifacts removes files and directories that are specific
 // to the ckeletin-go framework development and should not be in downstream projects.
 // This includes conformance testing (spec compliance), scaffold integration tests,
-// and the conformance mapping.
+// and the conformance mapping plus its generated report.
 func removeFrameworkOnlyArtifacts(projectRoot string) error {
 	artifacts := []string{
 		"test/conformance",
 		"conformance-mapping.yaml",
+		"conformance-report.json",
 	}
 	for _, artifact := range artifacts {
 		path := filepath.Join(projectRoot, artifact)

--- a/.ckeletin/scripts/scaffold/helpers_test.go
+++ b/.ckeletin/scripts/scaffold/helpers_test.go
@@ -467,6 +467,10 @@ func TestRemoveFrameworkOnlyArtifacts(t *testing.T) {
 			filepath.Join(tmpDir, "conformance-mapping.yaml"),
 			[]byte("spec_version: 0.3.0"), 0600))
 
+		require.NoError(t, os.WriteFile(
+			filepath.Join(tmpDir, "conformance-report.json"),
+			[]byte("{}"), 0600))
+
 		scaffoldTest := filepath.Join(tmpDir, "test", "integration")
 		require.NoError(t, os.MkdirAll(scaffoldTest, 0750))
 		require.NoError(t, os.WriteFile(
@@ -487,6 +491,9 @@ func TestRemoveFrameworkOnlyArtifacts(t *testing.T) {
 
 		_, err = os.Stat(filepath.Join(tmpDir, "conformance-mapping.yaml"))
 		assert.True(t, os.IsNotExist(err), "conformance-mapping.yaml should be removed")
+
+		_, err = os.Stat(filepath.Join(tmpDir, "conformance-report.json"))
+		assert.True(t, os.IsNotExist(err), "conformance-report.json should be removed")
 
 		_, err = os.Stat(filepath.Join(scaffoldTest, "scaffold_init_test.go"))
 		assert.True(t, os.IsNotExist(err), "scaffold_init_test.go should be removed")

--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,7 @@
 # YAML files
 *.yml text eol=lf
 *.yaml text eol=lf
+
+# JSON files (conformance-report.json is byte-compared by the conform sync guard,
+# so it must be LF on every platform or the guard false-fails on a CRLF checkout)
+*.json text eol=lf

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -332,9 +332,15 @@ tasks:
   # === Conformance ===
 
   conform:
-    desc: Generate CKSPEC conformance report from mapping
+    desc: Validate CKSPEC conformance against the spec (runs checks + report sync guard)
     cmds:
       - bash .ckeletin/scripts/conform.sh {{.CLI_ARGS}}
+
+  generate:conformance-report:
+    desc: Regenerate conformance-report.json (machine-readable report) from the mapping
+    cmds:
+      - bash .ckeletin/scripts/gen-conformance-report.sh > conformance-report.json
+      - 'echo "✅ conformance-report.json regenerated from conformance-mapping.yaml"'
 
   # === Project-Specific Tasks ===
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -339,8 +339,15 @@ tasks:
   generate:conformance-report:
     desc: Regenerate conformance-report.json (machine-readable report) from the mapping
     cmds:
-      - bash .ckeletin/scripts/gen-conformance-report.sh > conformance-report.json
-      - 'echo "✅ conformance-report.json regenerated from conformance-mapping.yaml"'
+      # Write to a temp file and move into place only on success, so a failed
+      # generation never truncates the committed report.
+      - |
+        tmp=$(mktemp ./conformance-report.json.XXXXXX)
+        trap 'rm -f "$tmp"' EXIT
+        bash .ckeletin/scripts/gen-conformance-report.sh > "$tmp"
+        mv "$tmp" conformance-report.json
+        trap - EXIT
+        echo "✅ conformance-report.json regenerated from conformance-mapping.yaml"
 
   # === Project-Specific Tasks ===
 

--- a/conformance-report.json
+++ b/conformance-report.json
@@ -1,0 +1,415 @@
+{
+  "implementation": "ckeletin-go",
+  "requirements": {
+    "CKSPEC-AGENT-001": {
+      "checks": [
+        "test -f AGENTS.md"
+      ],
+      "enforcement_level": "script",
+      "evidence": "AGENTS.md exists (358+ lines). Covers project purpose, directory structure, all task commands, coding conventions, ADR lookup, testing strategy, troubleshooting.\n",
+      "status": "met",
+      "violation_evidence": null,
+      "violation_tests": [
+        "test/conformance/violation_test.go::TestViolation_AGENT001_MissingAgentsMd"
+      ]
+    },
+    "CKSPEC-AGENT-002": {
+      "checks": [],
+      "enforcement_level": "honor-system",
+      "evidence": "AGENTS.md contains no Claude/Gemini/Copilot-specific instructions. Provider content is in CLAUDE.md, .cursorrules, copilot-instructions.md.\n",
+      "status": "met",
+      "violation_evidence": "AGENTS.md's only provider mentions are file-tree references (e.g. 'CLAUDE.md # Claude Code-specific rules'); a grep cannot distinguish a provider reference from a provider instruction, so the absence of provider-specific instructions is verified at review.\n",
+      "violation_tests": []
+    },
+    "CKSPEC-AGENT-003": {
+      "checks": [
+        "grep -qE 'AGENTS\\.md' CLAUDE.md"
+      ],
+      "enforcement_level": "script",
+      "evidence": "CLAUDE.md references AGENTS.md first. No project knowledge duplicated. .cursorrules and copilot-instructions.md also reference AGENTS.md.\n",
+      "status": "met",
+      "violation_evidence": "If a provider guide stops referencing AGENTS.md, the grep check fails.\n",
+      "violation_tests": []
+    },
+    "CKSPEC-AGENT-004": {
+      "checks": [
+        "grep -qiE 'Commands' AGENTS.md",
+        "grep -qiE 'Troubleshoot' AGENTS.md"
+      ],
+      "enforcement_level": "script",
+      "evidence": "AGENTS.md is self-sufficient: project purpose, directory tree, all task commands, coding conventions, ADR table, git workflow, troubleshooting with cascading fix order.\n",
+      "status": "met",
+      "violation_evidence": "Removing the required sections from AGENTS.md fails the section grep checks.\n",
+      "violation_tests": []
+    },
+    "CKSPEC-AGENT-005": {
+      "checks": [],
+      "enforcement_level": "honor-system",
+      "evidence": "CLI is primary interface. All operations via task commands. --output json provides machine-readable responses. No protocol layer required.\n",
+      "status": "met",
+      "violation_evidence": "'The CLI is the agent interface' is an architectural property (no separate protocol/daemon layer), verified by inspecting the design rather than a single artifact. Adding a non-CLI protocol layer is caught at architecture review.\n",
+      "violation_tests": []
+    },
+    "CKSPEC-ARCH-001": {
+      "checks": [
+        "task validate:layering"
+      ],
+      "enforcement_level": "linter",
+      "evidence": ".go-arch-lint.yml defines four layers: commands (cmd/), business (internal/ping, docs, dev, progress, check), infrastructure (.ckeletin/pkg/*, internal/config/commands, internal/ui, internal/xdg). Entry layer is main.go (36 lines). task validate:layering passes.\n",
+      "status": "met",
+      "violation_evidence": null,
+      "violation_tests": [
+        "test/conformance/violation_test.go::TestViolation_ARCH001_FileOutsideComponent"
+      ]
+    },
+    "CKSPEC-ARCH-002": {
+      "checks": [
+        "task validate:layering"
+      ],
+      "enforcement_level": "linter",
+      "evidence": "go-arch-lint enforces directed dependencies. Business mayDependOn infrastructure only. Infrastructure mayDependOn nothing.\n",
+      "status": "met",
+      "violation_evidence": null,
+      "violation_tests": [
+        "test/conformance/violation_test.go::TestViolation_ARCH002_ReverseDepBusinessImportsCmd"
+      ]
+    },
+    "CKSPEC-ARCH-003": {
+      "checks": [
+        "task validate:layering"
+      ],
+      "enforcement_level": "linter",
+      "evidence": "depOnAnyVendor:false enables vendor import checking. canUse rules restrict Cobra and pflag to commands layer only. Business and infrastructure cannot import them.\n",
+      "status": "met",
+      "violation_evidence": null,
+      "violation_tests": [
+        "test/conformance/violation_test.go::TestViolation_ARCH003_BusinessImportsCobra"
+      ]
+    },
+    "CKSPEC-ARCH-004": {
+      "checks": [
+        "task validate:layering"
+      ],
+      "enforcement_level": "linter",
+      "evidence": "go-arch-lint enforces business packages cannot import each other. Each business package mayDependOn infrastructure only.\n",
+      "status": "met",
+      "violation_evidence": null,
+      "violation_tests": [
+        "test/conformance/violation_test.go::TestViolation_ARCH004_BusinessImportsBusiness"
+      ]
+    },
+    "CKSPEC-ARCH-005": {
+      "checks": [
+        "task validate:layering"
+      ],
+      "enforcement_level": "linter",
+      "evidence": "go-arch-lint enforces infrastructure mayDependOn nothing. Cannot import business or command layers.\n",
+      "status": "met",
+      "violation_evidence": null,
+      "violation_tests": [
+        "test/conformance/violation_test.go::TestViolation_ARCH005_InfraImportsBusiness"
+      ]
+    },
+    "CKSPEC-ARCH-006": {
+      "checks": [
+        "task validate:package-organization",
+        "task validate:commands"
+      ],
+      "enforcement_level": "script",
+      "evidence": "main.go is 36 lines. validate-package-organization.sh verifies only main.go and main_test.go exist at root. validate-command-patterns.sh checks command files are under 80 lines.\n",
+      "status": "met",
+      "violation_evidence": null,
+      "violation_tests": [
+        "test/conformance/violation_test.go::TestViolation_ARCH006_OversizedCommand"
+      ]
+    },
+    "CKSPEC-ARCH-007": {
+      "checks": [
+        "task validate:package-organization"
+      ],
+      "enforcement_level": "script",
+      "evidence": "validate-package-organization.sh checks all Go files are in designated directories (cmd/, internal/, pkg/, .ckeletin/). Only main.go/main_test.go at root.\n",
+      "status": "met",
+      "violation_evidence": null,
+      "violation_tests": [
+        "test/conformance/violation_test.go::TestViolation_ARCH007_GoFileInRoot"
+      ]
+    },
+    "CKSPEC-CL-001": {
+      "checks": [
+        "test -f CHANGELOG.md"
+      ],
+      "enforcement_level": "script",
+      "evidence": "CHANGELOG.md exists in repository root.",
+      "status": "met",
+      "violation_evidence": null,
+      "violation_tests": [
+        "test/conformance/violation_test.go::TestViolation_CL001_MissingChangelogMd"
+      ]
+    },
+    "CKSPEC-CL-002": {
+      "checks": [
+        "grep -qiE 'keepachangelog' CHANGELOG.md"
+      ],
+      "enforcement_level": "script",
+      "evidence": "CHANGELOG.md uses Keep a Changelog format with all six categories. Versions in reverse chronological order.\n",
+      "status": "met",
+      "violation_evidence": "Dropping the Keep a Changelog format/reference from CHANGELOG.md fails the grep check.\n",
+      "violation_tests": []
+    },
+    "CKSPEC-CL-003": {
+      "checks": [
+        "grep -qE '^## \\[.+\\] - [0-9]{4}-[0-9]{2}-[0-9]{2}' CHANGELOG.md"
+      ],
+      "enforcement_level": "script",
+      "evidence": "All dates use YYYY-MM-DD format.",
+      "status": "met",
+      "violation_evidence": "A non-ISO-8601 release date fails the date-format grep check.\n",
+      "violation_tests": []
+    },
+    "CKSPEC-CL-004": {
+      "checks": [
+        "grep -qE '^## \\[[0-9]+\\.[0-9]+\\.[0-9]+\\]' CHANGELOG.md"
+      ],
+      "enforcement_level": "script",
+      "evidence": "CHANGELOG.md states adherence to SemVer. Version numbers follow MAJOR.MINOR.PATCH throughout.\n",
+      "status": "met",
+      "violation_evidence": "A non-SemVer version header fails the grep check.\n",
+      "violation_tests": []
+    },
+    "CKSPEC-CL-005": {
+      "checks": [
+        "grep -qE '^## \\[Unreleased\\]' CHANGELOG.md"
+      ],
+      "enforcement_level": "script",
+      "evidence": "[Unreleased] section present at top of CHANGELOG.md.",
+      "status": "met",
+      "violation_evidence": "Removing the Unreleased section fails the grep check.\n",
+      "violation_tests": []
+    },
+    "CKSPEC-CL-006": {
+      "checks": [],
+      "enforcement_level": "honor-system",
+      "evidence": "Changelog entries are human-written at user-relevant granularity. Not git log dumps.\n",
+      "status": "met",
+      "violation_evidence": "Distinguishing human-curated, user-relevant changelog prose from an auto-generated git-log dump is an editorial judgment no grep can make reliably. Enforced at review; a git-log-style dump is caught there.\n",
+      "violation_tests": []
+    },
+    "CKSPEC-CL-007": {
+      "checks": [
+        "grep -qE '^\\[.+\\]: https?://.+/compare/' CHANGELOG.md"
+      ],
+      "enforcement_level": "script",
+      "evidence": "Reference-style comparison links at bottom of CHANGELOG.md for all versions.\n",
+      "status": "met",
+      "violation_evidence": "Removing the reference-style compare links fails the grep check.\n",
+      "violation_tests": []
+    },
+    "CKSPEC-ENF-001": {
+      "checks": [],
+      "enforcement_level": "honor-system",
+      "evidence": "ADR-014 enforcement audit: 12/14 ADRs fully automated, 1 partial (ADR-008 GoReleaser), 1 honor system (ADR-007 Bubble Tea). 23 automated checks run via task check. Enforcement coverage is verified by human review of the audit table, not a targeted check.\n",
+      "status": "met",
+      "violation_evidence": "Meta-requirement: the project must prefer automated enforcement. Its satisfaction is the aggregate of the other requirements' enforcement levels (tracked in the ADR-014 audit table and surfaced by the conform report's automated-vs-analysis split), assessed at review rather than by one check.\n",
+      "violation_tests": []
+    },
+    "CKSPEC-ENF-002": {
+      "checks": [
+        "test -f .golangci.yml",
+        "test -f .semgrep.yml"
+      ],
+      "enforcement_level": "script",
+      "evidence": "All ladder levels used. Linter: go-arch-lint + golangci-lint. SAST: 12 semgrep rules. Scripts: 9 validate-*.sh + 16 check-*.sh. CI: GitHub Actions. Honor system: ADR-007 (documented as last resort). The ladder's existence is verified by review, not a targeted check.\n",
+      "status": "met",
+      "violation_evidence": "Removing the linter (.golangci.yml) or SAST (.semgrep.yml) config fails the test checks.\n",
+      "violation_tests": []
+    },
+    "CKSPEC-ENF-003": {
+      "checks": [
+        "grep -qiE 'gap|honor.system|partial' .ckeletin/docs/adr/014-adr-enforcement-policy.md"
+      ],
+      "enforcement_level": "script",
+      "evidence": "ADR-014 enforcement audit table documents gaps explicitly. ADR-007: honor system. ADR-008: partial. Gap documentation is verified by human review of the audit table.\n",
+      "status": "met",
+      "violation_evidence": "If ADR-014 stops documenting gaps, the grep check fails.\n",
+      "violation_tests": []
+    },
+    "CKSPEC-ENF-004": {
+      "checks": [
+        "grep -qiE 'audit table|enforcement.*audit' .ckeletin/docs/adr/014-adr-enforcement-policy.md"
+      ],
+      "enforcement_level": "script",
+      "evidence": "ADR-014 contains living enforcement audit table tracking all 14 ADRs with enforcement mechanism, status, and gaps. Table existence verified by review.\n",
+      "status": "met",
+      "violation_evidence": "If the ADR-014 audit table is removed, the grep check fails.\n",
+      "violation_tests": []
+    },
+    "CKSPEC-ENF-005": {
+      "checks": [
+        "test -f conformance-mapping.yaml",
+        "test -f .ckeletin/scripts/conform.sh"
+      ],
+      "enforcement_level": "script",
+      "evidence": "task conform validates all 38 requirement IDs are present in conformance-mapping.yaml before running checks. Missing IDs cause the generator to fail with a non-zero exit code. The count is machine-verified by the ENF-008 drift guard, not hand-maintained.\n",
+      "status": "met",
+      "violation_evidence": null,
+      "violation_tests": [
+        "test/conformance/violation_test.go::TestViolation_ENF005_IncompleteMapping"
+      ]
+    },
+    "CKSPEC-ENF-006": {
+      "checks": [
+        "go test -tags conformance ./test/conformance/..."
+      ],
+      "enforcement_level": "script",
+      "evidence": "15 violation tests prove enforcement for ARCH-001 through 007, OUT-001, OUT-005, TEST-003, AGENT-001, CL-001, ENF-005, and ENF-007. Requirements with honor-system enforcement are exempt. Run with: go test -tags conformance ./test/conformance/...\n",
+      "status": "met",
+      "violation_evidence": null,
+      "violation_tests": [
+        "test/conformance/violation_test.go::TestViolation_ENF006_MissingViolationTestFlagged"
+      ]
+    },
+    "CKSPEC-ENF-007": {
+      "checks": [
+        "grep -q 'Feedback signals' .ckeletin/scripts/conform.sh"
+      ],
+      "enforcement_level": "script",
+      "evidence": "task conform automatically reports feedback signals when checkable requirements lack violation tests or enforcement level is above honor-system without proof. Signals are structural, not volitional.\n",
+      "status": "met",
+      "violation_evidence": "The violation test verifies the conform script contains feedback signal logic (string presence), not that it produces correct output \u2014 running conform.sh from within the conformance test suite causes infinite recursion. Behavioral proof: task conform output shows feedback signals when enforcement claims lack violation tests. File: .ckeletin/scripts/conform.sh (FEEDBACK_FILE logic). File: test/conformance/violation_test.go (TestViolation_ENF007).\n",
+      "violation_tests": []
+    },
+    "CKSPEC-ENF-008": {
+      "checks": [
+        "grep -q 'machine-anchored' .ckeletin/scripts/conform.sh",
+        "grep -q 'met but unanchored' .ckeletin/scripts/conform.sh"
+      ],
+      "enforcement_level": "script",
+      "evidence": "conform.sh fails if any requirement claimed met lacks both an automated check and a violation_evidence anchor \u2014 no unanchored met-claims. Met requirements are tallied as machine-anchored vs analysis-with-evidence and the split is printed. The same gate also catches prose count drift (\"all N requirement\").\n",
+      "status": "met",
+      "violation_evidence": "The anchoring gate is conform.sh itself; a violation test that ran conform.sh from inside the conformance suite would recurse (same constraint as ENF-007). Behavioral proof: stripping a met requirement's checks and violation_evidence makes task conform fail with \"met but unanchored\". File: .ckeletin/scripts/conform.sh (ENF-008 anchoring gate + the automated-vs-analysis tally).\n",
+      "violation_tests": []
+    },
+    "CKSPEC-ENF-009": {
+      "checks": [
+        "grep -q 'CKSPEC Conformance' .github/workflows/ci.yml",
+        "grep -qE 'needs:.*conformance' .github/workflows/ci.yml"
+      ],
+      "enforcement_level": "ci",
+      "evidence": ".github/workflows/ci.yml defines a CKSPEC Conformance job that runs task conform; the release job declares needs: [test-matrix, build, conformance], so no release can publish while conformance fails. A scheduled run opens a deduplicated drift issue. Verified end-to-end via workflow_dispatch with the conformance job green.\n",
+      "status": "met",
+      "violation_evidence": "Enforcement is CI-structural \u2014 a job dependency in the release pipeline that a unit test cannot exercise. Proof is the workflow itself: the release job's needs: list includes conformance, so the release will not run while the conformance job fails. File: .github/workflows/ci.yml (conformance job + release needs).\n",
+      "violation_tests": []
+    },
+    "CKSPEC-OUT-001": {
+      "checks": [
+        "task validate:output"
+      ],
+      "enforcement_level": "script",
+      "evidence": "ADR-013 defines 3-stream model. Logger writes console to stderr, file to JSON. internal/ui renders to stdout. validate-output-patterns.sh enforces separation.\n",
+      "status": "met",
+      "violation_evidence": null,
+      "violation_tests": [
+        "test/conformance/violation_test.go::TestViolation_OUT001_BusinessUsesOsStdout"
+      ]
+    },
+    "CKSPEC-OUT-002": {
+      "checks": [
+        "grep -rq 'IsJSONMode' .ckeletin/pkg/output"
+      ],
+      "enforcement_level": "script",
+      "evidence": "--output json flag on all commands. output.IsJSONMode() check in renderer.go. JSONEnvelope to stdout in JSON mode. Verified by unit tests in cmd/*_test.go, not a targeted enforcement check.\n",
+      "status": "met",
+      "violation_evidence": "Removing the JSON output mode (IsJSONMode plumbing) fails the grep check.\n",
+      "violation_tests": []
+    },
+    "CKSPEC-OUT-003": {
+      "checks": [
+        "grep -rq 'type JSONEnvelope' .ckeletin/pkg/output"
+      ],
+      "enforcement_level": "script",
+      "evidence": "JSONEnvelope struct in .ckeletin/pkg/output/json.go with Status, Command, Data, Error fields. JSONResponder interface for custom payloads. Verified by unit tests, not a targeted enforcement check.\n",
+      "status": "met",
+      "violation_evidence": "Removing the JSONEnvelope struct fails the grep check.\n",
+      "violation_tests": []
+    },
+    "CKSPEC-OUT-004": {
+      "checks": [
+        "grep -qE 'log\\.Debug' internal/ui/renderer.go"
+      ],
+      "enforcement_level": "script",
+      "evidence": "RenderSuccess and RenderError in renderer.go log.Debug() raw data to audit log file while rendering formatted text to stdout. Debug level ensures shadow logs reach file logger without polluting console. Verified by unit tests.\n",
+      "status": "met",
+      "violation_evidence": "Removing the shadow log.Debug from the renderer fails the grep check.\n",
+      "violation_tests": []
+    },
+    "CKSPEC-OUT-005": {
+      "checks": [
+        "task validate:output"
+      ],
+      "enforcement_level": "script",
+      "evidence": "validate-output-patterns.sh detects fmt.Print* and os.Stdout in internal/* (excluding ui/ and tests). Business logic must use internal/ui for output.\n",
+      "status": "met",
+      "violation_evidence": null,
+      "violation_tests": [
+        "test/conformance/violation_test.go::TestViolation_OUT005_BusinessUsesFmtPrint"
+      ]
+    },
+    "CKSPEC-OUT-006": {
+      "checks": [
+        "grep -qE 'commit %s, built at %s' cmd/root.go"
+      ],
+      "enforcement_level": "test",
+      "evidence": "cmd/root.go composes RootCmd.Version as \"<version>, commit <commit>, built at <date>\" from the Version, Commit and Date package vars injected via ldflags (see Taskfile.yml LDFLAGS). So `<binary> --version` emits all three build-identity fields; TestVersionFlag asserts the commit and build-date fields are present in the output.\n",
+      "status": "met",
+      "violation_evidence": "Removing any build-identity field from the cmd/root.go version template (or dropping its ldflags injection) takes it out of `--version`; both the grep check and TestVersionFlag fail, so the regression cannot land green.\n",
+      "violation_tests": []
+    },
+    "CKSPEC-TEST-001": {
+      "checks": [],
+      "enforcement_level": "honor-system",
+      "evidence": "TDD mandatory per AGENTS.md and CLAUDE.md. Process discipline enforced through agent instructions, not tooling.\n",
+      "status": "met",
+      "violation_evidence": "TDD is a temporal property \u2014 'the failing test was written before the implementation' is not observable in the committed artifact, so no static check can decide it. Mandated by AGENTS.md/CLAUDE.md; a violation (implementation with no prior failing test) is caught at code review, not by tooling.\n",
+      "violation_tests": []
+    },
+    "CKSPEC-TEST-002": {
+      "checks": [
+        "test -f .ckeletin/scripts/check-coverage-project.sh"
+      ],
+      "enforcement_level": "script",
+      "evidence": "check-coverage-project.sh enforces 85% minimum. Pre-push hook runs coverage check. Current coverage: 90.3%.\n",
+      "status": "met",
+      "violation_evidence": "Destructive-to-test: reducing coverage below 85% to trigger the check would break the test suite. Enforcement mechanism is the script and its pre-push hook integration. File: .ckeletin/scripts/check-coverage-project.sh (MINIMUM_COVERAGE=85). File: .ckeletin/configs/lefthook.base.yml (pre-push runs coverage).\n",
+      "violation_tests": []
+    },
+    "CKSPEC-TEST-003": {
+      "checks": [
+        "test -f .semgrep.yml"
+      ],
+      "enforcement_level": "sast",
+      "evidence": "Semgrep rule ckeletin-no-mock-frameworks detects gomock/mockery/ testify-mock imports in Go files. Violation test creates a file with a gomock import and verifies semgrep catches it.\n",
+      "status": "met",
+      "violation_evidence": null,
+      "violation_tests": [
+        "test/conformance/violation_test.go::TestViolation_TEST003_MockFrameworkImport"
+      ]
+    },
+    "CKSPEC-TEST-004": {
+      "checks": [],
+      "enforcement_level": "honor-system",
+      "evidence": "AGENTS.md mandates atomic commits. Process discipline enforced through agent instructions and code review.\n",
+      "status": "met",
+      "violation_evidence": "Whether a commit atomically pairs a test with its implementation is a review judgment over commit contents, not a mechanically decidable property. Mandated by AGENTS.md and enforced at review.\n",
+      "violation_tests": []
+    }
+  },
+  "spec_version": "0.6.0",
+  "summary": {
+    "deferred": 0,
+    "met": 38,
+    "partial": 0,
+    "passed": true,
+    "total": 38
+  }
+}

--- a/test/conformance/violation_test.go
+++ b/test/conformance/violation_test.go
@@ -414,7 +414,7 @@ func TestViolation_CL001_MissingChangelogMd(t *testing.T) {
 
 // ---------------------------------------------------------------------------
 // CKSPEC-ENF-005: Conformance mapping completeness
-// Enforcement: task conform validates all 35 IDs present
+// Enforcement: task conform validates all 38 IDs present
 // Violation: mapping file missing a requirement
 // ---------------------------------------------------------------------------
 

--- a/test/conformance/violation_test.go
+++ b/test/conformance/violation_test.go
@@ -619,3 +619,40 @@ func TestViolation_ConformMapping_NonMikefarahYqRejected(t *testing.T) {
 	assert.NotContains(t, output, "Running checks",
 		"the yq-variant gate must fail fast, before running any checks\nOutput: %s", output)
 }
+
+// ---------------------------------------------------------------------------
+// Conformance tooling integrity: the published report MUST match the mapping.
+// Enforcement: conform.sh regenerates conformance-report.json from the mapping
+// (gen-conformance-report.sh) and fails — and so does the release gate — if the
+// committed report has drifted. This keeps the machine-readable report (which the
+// spec repo aggregates instead of hand-authoring conformance/ckeletin-go.yaml)
+// truthful. Violation: a stale committed report must be rejected.
+// ---------------------------------------------------------------------------
+
+func TestViolation_ConformReport_OutOfSyncRejected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("violation tests modify the source tree")
+	}
+
+	root := projectRoot(t)
+	reportPath := filepath.Join(root, "conformance-report.json")
+
+	original, err := os.ReadFile(reportPath)
+	require.NoError(t, err)
+
+	// Corrupt the committed report so it no longer matches the mapping.
+	require.NoError(t, os.WriteFile(reportPath, []byte("{\"summary\": {\"met\": 999}}\n"), 0644))
+	defer func() {
+		// Restore the original report regardless of assertion outcome.
+		os.WriteFile(reportPath, original, 0644)
+	}()
+
+	output, exitCode := runCheck(t, "bash", scriptPath(t, "conform.sh"))
+
+	assert.NotEqual(t, 0, exitCode,
+		"conform.sh must fail when conformance-report.json is out of sync\nOutput: %s", output)
+	assert.Contains(t, output, "out of sync",
+		"conform.sh must report the report drift\nOutput: %s", output)
+	assert.NotContains(t, output, "Running checks",
+		"the report-sync guard must fail fast, before running any checks\nOutput: %s", output)
+}


### PR DESCRIPTION
## What

Increment **B2** of automating the impl→spec conformance flow. Adds `conformance-report.json` — a **deterministic** JSON projection of `conformance-mapping.yaml` (header + summary totals + per-requirement `status`, `enforcement_level`, `evidence`, `checks`, `violation_tests`, `violation_evidence`).

This is the artifact the spec repo (`peiman/ckeletin`) will **aggregate** instead of hand-authoring `conformance/ckeletin-go.yaml` (B3), closing the manual impl→spec status flow. The requirements flow spec→impl is already automated (`conform.sh` fetches `requirements.json`); this makes the status flow symmetric.

## How

- **`gen-conformance-report.sh`** — the single generator. `yq` extracts the **data** (YAML-spec-defined, stable across yq versions); `python3` canonicalizes the **formatting** (sorted keys, fixed indent). So the committed report is byte-stable regardless of yq version — which is what makes the sync-check reliable across CI (yq 4.44.6) and local (any mikefarah yq v4). **No timestamp** in the file (a volatile field would break the sync-check; the aggregator stamps the fetch date).
- **`task generate:conformance-report`** regenerates it.
- **`conform.sh` report-sync guard** — regenerates in-memory and fails the build (and the release gate) if the committed report drifted from the mapping (mirrors the spec repo's `requirements.json` sync pattern, P9). Runs *after* the ENF-005 completeness check so a dropped requirement still fails as "unmapped", not as report drift.
- **`TestViolation_ConformReport_OutOfSyncRejected`** proves the guard.
- The scaffold removes `conformance-report.json` from downstream projects (like the mapping); `helpers_test.go` covers it.

## Verification
- `task conform` green: Report sync PASS, 38/38 met, 0 failed.
- Report is deterministic (regenerates byte-identical) and valid JSON.
- Sync guard fails fast on drift (recursion-free); full conformance suite + `task check` green.
- Cross-yq-version determinism verified in CI via a branch dispatch of `conformance.yml` (yq 4.44.6 regenerates to the same bytes as the committed report).

Next: **B3** — spec repo aggregates this published report (rust = graceful fallback).