### PR TITLE
fix: address external review findings (JSON contract, env coercion, completion, docs flag, coverage gate)

### DIFF
--- a/.ckeletin/Taskfile.yml
+++ b/.ckeletin/Taskfile.yml
@@ -1140,6 +1140,10 @@ tasks:
             echo ""
             task ckeletin:check:bash
           fi
+      # Enforce the project coverage threshold (85%) as part of the mandatory
+      # gate. The binary/bash check above measures coverage but does not gate on
+      # it; this is the authoritative threshold check (excludes TUI/demo code).
+      - task: test:coverage:project
       # Non-fatal footer: nudge when the framework (.ckeletin/) is behind upstream.
       # Throttled, time-boxed, CI-skipped and never fails the build (see the script).
       - cmd: '{{.SCRIPTS_DIR}}/check-framework-updates.sh'

--- a/.ckeletin/pkg/config/commands/docs_config.go
+++ b/.ckeletin/pkg/config/commands/docs_config.go
@@ -22,12 +22,14 @@ The documentation can be output in various formats using the --format flag.`,
 	ConfigPrefix: "app.docs",
 	FlagOverrides: map[string]string{
 		"app.docs.output_format": "format",
-		"app.docs.output_file":   "output",
+		// Named --output-file (not --output) so it does not shadow the global
+		// --output (output FORMAT) persistent flag.
+		"app.docs.output_file": "output-file",
 	},
 	Examples: []string{
 		"docs config",
 		"docs config --format yaml",
-		"docs config --output docs/config.md",
+		"docs config --output-file docs/config.md",
 	},
 	SeeAlso: []string{"ping"},
 }

--- a/.ckeletin/pkg/output/json.go
+++ b/.ckeletin/pkg/output/json.go
@@ -7,8 +7,16 @@ package output
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 )
+
+// ErrRendered is a sentinel returned by a command that has already written its
+// single JSON envelope to stdout but still needs to signal a non-zero exit.
+// main.go recognizes it and exits non-zero WITHOUT rendering a second envelope.
+// This keeps the "exactly one envelope per command" contract while preserving a
+// meaningful process exit code for JSON consumers that gate on $?.
+var ErrRendered = errors.New("output: result already rendered")
 
 // JSONEnvelope is the standard response wrapper for --output json mode.
 // Every command emits exactly one envelope to stdout.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,7 +282,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: ./coverage.txt
-          fail_ci_if_error: false  # Coverage enforced by check-coverage-project.sh
+          fail_ci_if_error: false  # codecov is informational; the 85% gate is enforced by `task check` (check-coverage-project.sh)
           verbose: true
           flags: unittests
           name: codecov-${{ steps.binary-name.outputs.name }}

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -126,6 +126,9 @@ vendors:
   # Configuration library
   viper:
     in: github.com/spf13/viper
+  # Type coercion for env-var config values (viper's own coercion dependency)
+  cast:
+    in: github.com/spf13/cast
 
   # Logging (base package + sub-packages like zerolog/log)
   zerolog:
@@ -172,6 +175,7 @@ deps:
       - cobra
       - pflag
       - viper
+      - cast
       - zerolog
 
   # Business logic uses infrastructure only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING — `docs config` output-file flag renamed to `--output-file`**: The flag that writes generated documentation to a file is now `--output-file` (previously `--output`), so the global `--output` flag consistently selects the output _format_. Update any scripts that use `docs config --output <path>`. (Previously `docs config --output json` created a file literally named `json`.)
+- **`config validate --output json` and `check --output json` now exit non-zero on failure**: Previously they exited `0` even when validation or checks failed, reporting the result only in the JSON envelope's `status`. Pipelines that gate on the process exit code will now correctly detect failures. The output is still exactly one JSON envelope.
+- **Environment variables for non-string config are now honored**: Boolean, integer, float, and list config values supplied via environment variables (e.g. `CKELETIN_GO_APP_PING_UI=true`) now take effect; previously they were silently dropped to the type's zero value.
+
+### Fixed
+
+- **`config validate --output json` emits exactly one JSON envelope**: It no longer interleaves human-readable text with the JSON envelope, restoring the one-envelope-per-command contract for machine consumers.
+- **`completion zsh|fish|powershell` generate the correct shell script**: The command previously ignored its argument and always emitted a bash script; each shell now gets its own script, and an unsupported shell is rejected.
+- **Unparseable config values are no longer silently ignored**: A value that cannot be coerced to its declared type (e.g. a mistyped boolean like `…=yse`) is now logged at `WARN` (with the key and offending value) instead of silently becoming the zero value.
+- **`task check` enforces the 85% project coverage threshold**: The coverage gate (`check-coverage-project.sh`) now runs as part of `task check`; previously overall coverage was measured but never gated.
+- **Refreshed stale documentation**: Corrected the Go version reference (now points at `.go-version` as the source of truth) and the default config path (`~/.config/<binary>/config.yaml`), and documented the `app.output_format` and `app.check.*` configuration options.
+
 ## [0.10.0] - 2026-04-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ All architectural decisions are documented in **[Architecture Decision Records](
 
 ### Prerequisites
 
-- **Go**: Version specified in `.go-version` (currently 1.26.1)
+- **Go**: Version specified in `.go-version` (the single source of truth)
 - **Task**: Install from [taskfile.dev](https://taskfile.dev/#/installation)
 - **Git**: For version control
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -424,7 +424,7 @@ tasks:
     cmds:
       - echo "Generating configuration documentation..."
       - mkdir -p docs
-      - ./{{.BINARY_NAME}} docs config --output=docs/configuration.md
+      - ./{{.BINARY_NAME}} docs config --output-file=docs/configuration.md
       - echo "Configuration documentation saved to docs/configuration.md"
     deps: [build]
 
@@ -433,7 +433,7 @@ tasks:
     cmds:
       - echo "Generating YAML configuration template..."
       - mkdir -p docs
-      - ./{{.BINARY_NAME}} docs config --format=yaml --output=docs/config-template.yaml
+      - ./{{.BINARY_NAME}} docs config --format=yaml --output-file=docs/config-template.yaml
       - echo "YAML template saved to docs/config-template.yaml"
     deps: [build]
 

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -25,9 +25,27 @@ PowerShell:
   %s completion powershell | Out-String | Invoke-Expression
 `, binaryName, binaryName, binaryName, binaryName),
 	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.MatchAll(cobra.MaximumNArgs(1), cobra.OnlyValidArgs),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Default to bash if no args provided:
-		return cmd.Root().GenBashCompletion(cmd.OutOrStdout())
+		// Default to bash when no shell is given (preserves prior behavior).
+		shell := "bash"
+		if len(args) > 0 {
+			shell = args[0]
+		}
+		out := cmd.OutOrStdout()
+		switch shell {
+		case "bash":
+			return cmd.Root().GenBashCompletion(out)
+		case "zsh":
+			return cmd.Root().GenZshCompletion(out)
+		case "fish":
+			return cmd.Root().GenFishCompletion(out, true)
+		case "powershell":
+			return cmd.Root().GenPowerShellCompletionWithDesc(out)
+		default:
+			return fmt.Errorf("unsupported shell %q (want bash, zsh, fish, or powershell)", shell)
+		}
 	},
 }
 

--- a/cmd/completion_shell_test.go
+++ b/cmd/completion_shell_test.go
@@ -1,0 +1,60 @@
+// cmd/completion_shell_test.go
+
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func genCompletion(t *testing.T, args ...string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	RootCmd.SetOut(&buf)
+	RootCmd.SetErr(&bytes.Buffer{})
+	RootCmd.SetArgs(append([]string{"completion"}, args...))
+	defer RootCmd.SetArgs(nil)
+	require.NoError(t, RootCmd.Execute())
+	return buf.String()
+}
+
+// TestCompletion_PerShell pins that each shell emits its OWN script, not bash for
+// everything.
+func TestCompletion_PerShell(t *testing.T) {
+	cases := []struct {
+		shell  string
+		marker string
+	}{
+		{"bash", "bash completion"},
+		{"zsh", "#compdef"},
+		{"fish", "fish completion"},
+		{"powershell", "Register-ArgumentCompleter"},
+	}
+	for _, tc := range cases {
+		out := genCompletion(t, tc.shell)
+		assert.Contains(t, out, tc.marker,
+			"`completion %s` must emit a %s script (marker %q)", tc.shell, tc.shell, tc.marker)
+	}
+}
+
+func TestCompletion_ZshDiffersFromBash(t *testing.T) {
+	assert.NotEqual(t, genCompletion(t, "bash"), genCompletion(t, "zsh"),
+		"zsh completion must differ from bash completion")
+}
+
+func TestCompletion_DefaultsToBash(t *testing.T) {
+	assert.Contains(t, genCompletion(t), "bash completion",
+		"completion with no shell arg should default to bash")
+}
+
+func TestCompletion_RejectsUnknownShell(t *testing.T) {
+	var buf bytes.Buffer
+	RootCmd.SetOut(&buf)
+	RootCmd.SetErr(&bytes.Buffer{})
+	RootCmd.SetArgs([]string{"completion", "tcsh"})
+	defer RootCmd.SetArgs(nil)
+	assert.Error(t, RootCmd.Execute(), "an unsupported shell should be rejected")
+}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/peiman/ckeletin-go/.ckeletin/pkg/config/validator"
+	"github.com/peiman/ckeletin-go/.ckeletin/pkg/output"
 	"github.com/spf13/cobra"
 )
 
@@ -81,11 +82,41 @@ func runConfigValidate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("validation failed: %w", err)
 	}
 
-	// Format and display results
-	validator.FormatResult(result, cmd.OutOrStdout())
+	exitErr := validator.ExitCodeForResult(result)
 
-	// Determine exit code and suppress usage on validation errors
-	if exitErr := validator.ExitCodeForResult(result); exitErr != nil {
+	// JSON mode: emit exactly one envelope (no human text). Like the `check`
+	// command, return nil afterward so main.go does not emit a second envelope —
+	// the envelope's status communicates success/failure.
+	if output.IsJSONMode() {
+		status := "success"
+		var jsonErr *output.JSONError
+		if exitErr != nil {
+			status = "error"
+			jsonErr = &output.JSONError{Message: exitErr.Error()}
+		}
+		errMsgs := make([]string, len(result.Errors))
+		for i, e := range result.Errors {
+			errMsgs[i] = e.Error()
+		}
+		if rerr := output.RenderJSON(cmd.OutOrStdout(), output.JSONEnvelope{
+			Status:  status,
+			Command: output.CommandName(),
+			Data: map[string]any{
+				"valid":       result.Valid,
+				"config_file": result.ConfigFile,
+				"errors":      errMsgs,
+				"warnings":    result.Warnings,
+			},
+			Error: jsonErr,
+		}); rerr != nil {
+			return fmt.Errorf("failed to write JSON output: %w", rerr)
+		}
+		return nil
+	}
+
+	// Text mode: human-readable formatting.
+	validator.FormatResult(result, cmd.OutOrStdout())
+	if exitErr != nil {
 		cmd.SilenceUsage = true
 		return exitErr
 	}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -111,6 +111,12 @@ func runConfigValidate(cmd *cobra.Command, args []string) error {
 		}); rerr != nil {
 			return fmt.Errorf("failed to write JSON output: %w", rerr)
 		}
+		// The single envelope is written; signal a non-zero exit on failure
+		// (errors or warnings) without main.go emitting a second envelope.
+		if exitErr != nil {
+			cmd.SilenceUsage = true
+			return output.ErrRendered
+		}
 		return nil
 	}
 

--- a/cmd/config_coercion_test.go
+++ b/cmd/config_coercion_test.go
@@ -1,0 +1,73 @@
+// cmd/config_coercion_test.go
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+// Env vars always arrive through viper as strings. These tests pin that
+// non-string config values provided as strings (the env-var case) are coerced
+// to their declared type instead of being silently dropped to the zero value.
+
+func TestGetConfigValueWithFlags_BoolFromEnvString(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+	viper.Set("app.ping.ui", "true") // as an env var would arrive
+
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("ui", false, "")
+
+	got := getConfigValueWithFlags[bool](cmd, "ui", "app.ping.ui")
+	assert.True(t, got, "string env value \"true\" must coerce to bool true, not fall back to false")
+}
+
+func TestGetConfigValueWithFlags_IntFromEnvString(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+	viper.Set("app.some.count", "42")
+
+	cmd := &cobra.Command{}
+	cmd.Flags().Int("count", 0, "")
+
+	got := getConfigValueWithFlags[int](cmd, "count", "app.some.count")
+	assert.Equal(t, 42, got, "string env value \"42\" must coerce to int 42")
+}
+
+func TestGetConfigValueWithFlags_StringStillWorks(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+	viper.Set("app.ping.output_message", "hello")
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("message", "", "")
+
+	got := getConfigValueWithFlags[string](cmd, "message", "app.ping.output_message")
+	assert.Equal(t, "hello", got)
+}
+
+func TestGetConfigValueWithFlags_FlagOverridesEnvCoercion(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+	viper.Set("app.ping.ui", "false")
+
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("ui", false, "")
+	_ = cmd.Flags().Set("ui", "true") // explicit flag wins over the env/config value
+
+	got := getConfigValueWithFlags[bool](cmd, "ui", "app.ping.ui")
+	assert.True(t, got, "an explicitly-set flag must override the (coerced) viper value")
+}
+
+func TestGetKeyValue_BoolFromEnvString(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+	viper.Set("app.feature.enabled", "true")
+
+	assert.True(t, getKeyValue[bool]("app.feature.enabled"),
+		"string env value \"true\" must coerce to bool true")
+}

--- a/cmd/config_coercion_test.go
+++ b/cmd/config_coercion_test.go
@@ -3,8 +3,12 @@
 package cmd
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/peiman/ckeletin-go/.ckeletin/pkg/logger"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -88,4 +92,27 @@ func TestGetKeyValue_StringSliceFromEnvString(t *testing.T) {
 
 	assert.Equal(t, []string{"a", "b", "c"}, getKeyValue[[]string]("app.some.list"),
 		"a delimited string env value must coerce to []string")
+}
+
+// TestCoerceViperValue_LogsAndIgnoresUnparseable pins that a value which cannot be
+// coerced (e.g. a typo'd bool env var) is NOT silently dropped to zero — it is
+// logged at WARN, so the failure is debuggable rather than invisible.
+func TestCoerceViperValue_LogsAndIgnoresUnparseable(t *testing.T) {
+	savedLogger, savedLevel := logger.SaveLoggerState()
+	defer logger.RestoreLoggerState(savedLogger, savedLevel)
+
+	var buf bytes.Buffer
+	log.Logger = zerolog.New(&buf)
+	zerolog.SetGlobalLevel(zerolog.WarnLevel)
+
+	viper.Reset()
+	defer viper.Reset()
+	viper.Set("app.feature.enabled", "yse") // typo'd bool — not coercible
+
+	got := getKeyValue[bool]("app.feature.enabled")
+	assert.False(t, got, "an unparseable value falls back to the zero value")
+	assert.Contains(t, buf.String(), "could not be coerced",
+		"a warning must be logged so the coercion failure is not silent")
+	assert.Contains(t, buf.String(), "app.feature.enabled",
+		"the warning must name the offending key")
 }

--- a/cmd/config_coercion_test.go
+++ b/cmd/config_coercion_test.go
@@ -71,3 +71,21 @@ func TestGetKeyValue_BoolFromEnvString(t *testing.T) {
 	assert.True(t, getKeyValue[bool]("app.feature.enabled"),
 		"string env value \"true\" must coerce to bool true")
 }
+
+func TestGetKeyValue_Float64FromEnvString(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+	viper.Set("app.some.ratio", "3.14")
+
+	assert.Equal(t, 3.14, getKeyValue[float64]("app.some.ratio"),
+		"string env value \"3.14\" must coerce to float64 3.14")
+}
+
+func TestGetKeyValue_StringSliceFromEnvString(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+	viper.Set("app.some.list", "a b c") // env-var shape: a delimited string, not a native slice
+
+	assert.Equal(t, []string{"a", "b", "c"}, getKeyValue[[]string]("app.some.list"),
+		"a delimited string env value must coerce to []string")
+}

--- a/cmd/config_validate_json_test.go
+++ b/cmd/config_validate_json_test.go
@@ -1,0 +1,78 @@
+// cmd/config_validate_json_test.go
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/peiman/ckeletin-go/.ckeletin/pkg/logger"
+	"github.com/peiman/ckeletin-go/.ckeletin/pkg/output"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runConfigValidateJSON drives `config validate --file <path> --output json` and
+// returns the captured stdout.
+func runConfigValidateJSON(t *testing.T, cfgYAML string) string {
+	t.Helper()
+
+	savedLogger, savedLevel := logger.SaveLoggerState()
+	defer logger.RestoreLoggerState(savedLogger, savedLevel)
+
+	origCfgFile := cfgFile
+	origStatus := configFileStatus
+	origUsed := configFileUsed
+	defer resetOutputJSONTestState(origCfgFile, origStatus, origUsed)
+	defer func() { validateConfigFile = "" }()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgYAML), 0o600))
+
+	var stdout bytes.Buffer
+	RootCmd.SetOut(&stdout)
+	RootCmd.SetErr(&bytes.Buffer{})
+	RootCmd.SetArgs([]string{"config", "validate", "--file", cfgPath, "--output", "json"})
+
+	// Exit status is communicated via the JSON envelope (like `check`), so the
+	// returned error is not asserted here.
+	_ = RootCmd.Execute()
+	return stdout.String()
+}
+
+// TestConfigValidateJSON_WarningsEmitSingleEnvelope is the regression test for the
+// JSON-contract bug: a config that produces warnings must yield exactly ONE JSON
+// envelope on stdout — no human-readable text from FormatResult leaking in front
+// of it.
+func TestConfigValidateJSON_WarningsEmitSingleEnvelope(t *testing.T) {
+	// Valid config, but with an unknown key → a warning (the path that leaked text).
+	out := runConfigValidateJSON(t, "app:\n  log_level: info\nunknown_key_xyz: 1\n")
+
+	assert.NotContains(t, out, "Validating:", "no human text may precede the JSON envelope")
+	assert.NotContains(t, out, "⚠️", "no human warning text may leak to stdout")
+
+	var envelope output.JSONEnvelope
+	require.NoError(t, json.Unmarshal([]byte(out), &envelope),
+		"stdout must be exactly one JSON envelope, got: %q", out)
+	assert.Equal(t, "validate", envelope.Command)
+	assert.Equal(t, "error", envelope.Status, "warnings map to a non-zero result")
+	require.NotNil(t, envelope.Error)
+}
+
+// TestConfigValidateJSON_ValidEmitsSingleEnvelope verifies the success path emits a
+// single JSON envelope too (previously it emitted only human text and no envelope).
+func TestConfigValidateJSON_ValidEmitsSingleEnvelope(t *testing.T) {
+	out := runConfigValidateJSON(t, "app:\n  log_level: info\n")
+
+	assert.NotContains(t, out, "Validating:", "no human text may precede the JSON envelope")
+
+	var envelope output.JSONEnvelope
+	require.NoError(t, json.Unmarshal([]byte(out), &envelope),
+		"stdout must be exactly one JSON envelope, got: %q", out)
+	assert.Equal(t, "validate", envelope.Command)
+	assert.NotNil(t, envelope.Data)
+}

--- a/cmd/config_validate_json_test.go
+++ b/cmd/config_validate_json_test.go
@@ -16,8 +16,9 @@ import (
 )
 
 // runConfigValidateJSON drives `config validate --file <path> --output json` and
-// returns the captured stdout.
-func runConfigValidateJSON(t *testing.T, cfgYAML string) string {
+// returns the captured stdout plus the error returned by Execute (which carries
+// the exit-code signal).
+func runConfigValidateJSON(t *testing.T, cfgYAML string) (string, error) {
 	t.Helper()
 
 	savedLogger, savedLevel := logger.SaveLoggerState()
@@ -38,10 +39,8 @@ func runConfigValidateJSON(t *testing.T, cfgYAML string) string {
 	RootCmd.SetErr(&bytes.Buffer{})
 	RootCmd.SetArgs([]string{"config", "validate", "--file", cfgPath, "--output", "json"})
 
-	// Exit status is communicated via the JSON envelope (like `check`), so the
-	// returned error is not asserted here.
-	_ = RootCmd.Execute()
-	return stdout.String()
+	err := RootCmd.Execute()
+	return stdout.String(), err
 }
 
 // TestConfigValidateJSON_WarningsEmitSingleEnvelope is the regression test for the
@@ -50,7 +49,7 @@ func runConfigValidateJSON(t *testing.T, cfgYAML string) string {
 // of it.
 func TestConfigValidateJSON_WarningsEmitSingleEnvelope(t *testing.T) {
 	// Valid config, but with an unknown key → a warning (the path that leaked text).
-	out := runConfigValidateJSON(t, "app:\n  log_level: info\nunknown_key_xyz: 1\n")
+	out, err := runConfigValidateJSON(t, "app:\n  log_level: info\nunknown_key_xyz: 1\n")
 
 	assert.NotContains(t, out, "Validating:", "no human text may precede the JSON envelope")
 	assert.NotContains(t, out, "⚠️", "no human warning text may leak to stdout")
@@ -61,14 +60,19 @@ func TestConfigValidateJSON_WarningsEmitSingleEnvelope(t *testing.T) {
 	assert.Equal(t, "validate", envelope.Command)
 	assert.Equal(t, "error", envelope.Status, "warnings map to a non-zero result")
 	require.NotNil(t, envelope.Error)
+
+	// The envelope is written, but the command still signals a non-zero exit
+	// (parity with text mode, which exits 1) via the ErrRendered sentinel.
+	assert.ErrorIs(t, err, output.ErrRendered, "JSON-mode validation failure must signal non-zero exit")
 }
 
 // TestConfigValidateJSON_ValidEmitsSingleEnvelope verifies the success path emits a
 // single JSON envelope too (previously it emitted only human text and no envelope).
 func TestConfigValidateJSON_ValidEmitsSingleEnvelope(t *testing.T) {
-	out := runConfigValidateJSON(t, "app:\n  log_level: info\n")
+	out, err := runConfigValidateJSON(t, "app:\n  log_level: info\n")
 
 	assert.NotContains(t, out, "Validating:", "no human text may precede the JSON envelope")
+	assert.NoError(t, err, "a valid config exits 0 (nil error)")
 
 	var envelope output.JSONEnvelope
 	require.NoError(t, json.Unmarshal([]byte(out), &envelope),

--- a/cmd/docs_output_flag_test.go
+++ b/cmd/docs_output_flag_test.go
@@ -1,0 +1,27 @@
+// cmd/docs_output_flag_test.go
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDocsConfig_OutputFileNotOutput pins that the `docs config` command's output
+// FILE flag is named --output-file, not --output. A local --output flag shadows
+// the global --output (output FORMAT) flag, so `docs config --output json` would
+// create a file literally named "json" instead of selecting JSON format.
+func TestDocsConfig_OutputFileNotOutput(t *testing.T) {
+	docsCmd := findSubcommand(RootCmd, "docs")
+	require.NotNil(t, docsCmd, "docs command must exist")
+	configSub := findSubcommand(docsCmd, "config")
+	require.NotNil(t, configSub, "docs config command must exist")
+
+	assert.NotNil(t, configSub.Flags().Lookup("output-file"),
+		"docs config should expose the output file as --output-file")
+
+	assert.Nil(t, configSub.LocalFlags().Lookup("output"),
+		"docs config must NOT define a local --output flag — it shadows the global --output (format) flag")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,7 @@ import (
 	"github.com/peiman/ckeletin-go/internal/xdg"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -609,34 +610,51 @@ func getKeyValue[T any](viperKey string) T {
 //
 // Environment variables always arrive through viper as strings, so a plain
 // viper.Get + Go type assertion (v.(bool)) silently fails for non-string config
-// (bool/int/float/[]string) and drops the value to its zero. viper's typed
-// getters use spf13/cast to coerce (e.g. "true" -> true, "42" -> 42), which is
-// the behavior users expect from env-var configuration.
+// (bool/int/float/[]string) and drops the value to its zero. spf13/cast coerces
+// (e.g. "true" -> true, "42" -> 42), which is the behavior users expect from
+// env-var configuration.
 //
-// Presence is detected with viper.Get != nil (which works for env-only keys,
-// unlike viper.IsSet); the second return value reports whether the key was set.
+// A value that genuinely cannot be coerced (e.g. a typo'd env var like
+// FAIL_FAST=yse) is NOT silently dropped to zero — it is logged at WARN and the
+// key is reported as unset so a default or flag can still win. Presence is
+// detected with viper.Get != nil (which works for env-only keys, unlike
+// viper.IsSet); the second return value reports whether a usable value was found.
 func coerceViperValue[T any](viperKey string) (T, bool) {
 	var zero T
-	if viper.Get(viperKey) == nil {
+	raw := viper.Get(viperKey)
+	if raw == nil {
 		return zero, false
 	}
+
+	var (
+		val any
+		err error
+	)
 	switch any(zero).(type) {
 	case string:
-		return any(viper.GetString(viperKey)).(T), true
+		val, err = cast.ToStringE(raw)
 	case bool:
-		return any(viper.GetBool(viperKey)).(T), true
+		val, err = cast.ToBoolE(raw)
 	case int:
-		return any(viper.GetInt(viperKey)).(T), true
+		val, err = cast.ToIntE(raw)
 	case float64:
-		return any(viper.GetFloat64(viperKey)).(T), true
+		val, err = cast.ToFloat64E(raw)
 	case []string:
-		return any(viper.GetStringSlice(viperKey)).(T), true
+		val, err = cast.ToStringSliceE(raw)
 	default:
-		if v := viper.Get(viperKey); v != nil {
-			if typedValue, ok := v.(T); ok {
-				return typedValue, true
-			}
+		if typedValue, ok := raw.(T); ok {
+			return typedValue, true
 		}
 		return zero, false
 	}
+
+	if err != nil {
+		log.Warn().
+			Str("key", viperKey).
+			Interface("value", raw).
+			Err(err).
+			Msg("config value could not be coerced to its declared type; ignoring it")
+		return zero, false
+	}
+	return val.(T), true
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -500,11 +500,9 @@ func setupCommandConfig(cmd *cobra.Command) {
 func getConfigValueWithFlags[T any](cmd *cobra.Command, flagName string, viperKey string) T {
 	var value T
 
-	// Get the value from viper first (this will be from config file or env var)
-	if v := viper.Get(viperKey); v != nil {
-		if typedValue, ok := v.(T); ok {
-			value = typedValue
-		}
+	// Get the value from viper first (config file or env var), coerced to T.
+	if v, ok := coerceViperValue[T](viperKey); ok {
+		value = v
 	}
 
 	// If the flag was explicitly set, override the viper value
@@ -601,10 +599,44 @@ func getConfigValueWithFlags[T any](cmd *cobra.Command, flagName string, viperKe
 //   - The configuration value of type T, or zero value if not found/conversion fails
 func getKeyValue[T any](viperKey string) T {
 	var zero T
-	if v := viper.Get(viperKey); v != nil {
-		if typedValue, ok := v.(T); ok {
-			return typedValue
-		}
+	if v, ok := coerceViperValue[T](viperKey); ok {
+		return v
 	}
 	return zero
+}
+
+// coerceViperValue reads viperKey and coerces the stored value to type T.
+//
+// Environment variables always arrive through viper as strings, so a plain
+// viper.Get + Go type assertion (v.(bool)) silently fails for non-string config
+// (bool/int/float/[]string) and drops the value to its zero. viper's typed
+// getters use spf13/cast to coerce (e.g. "true" -> true, "42" -> 42), which is
+// the behavior users expect from env-var configuration.
+//
+// Presence is detected with viper.Get != nil (which works for env-only keys,
+// unlike viper.IsSet); the second return value reports whether the key was set.
+func coerceViperValue[T any](viperKey string) (T, bool) {
+	var zero T
+	if viper.Get(viperKey) == nil {
+		return zero, false
+	}
+	switch any(zero).(type) {
+	case string:
+		return any(viper.GetString(viperKey)).(T), true
+	case bool:
+		return any(viper.GetBool(viperKey)).(T), true
+	case int:
+		return any(viper.GetInt(viperKey)).(T), true
+	case float64:
+		return any(viper.GetFloat64(viperKey)).(T), true
+	case []string:
+		return any(viper.GetStringSlice(viperKey)).(T), true
+	default:
+		if v := viper.Get(viperKey); v != nil {
+			if typedValue, ok := v.(T); ok {
+				return typedValue, true
+			}
+		}
+		return zero, false
+	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -735,8 +735,11 @@ func TestGetConfigValue_FlagErrors(t *testing.T) {
 	}
 }
 
-// TestGetConfigValue_ViperTypeMismatch tests behavior when viper has wrong type
-func TestGetConfigValue_ViperTypeMismatch(t *testing.T) {
+// TestGetConfigValue_ViperTypeCoercion tests that values are coerced to the
+// requested type using viper's typed getters (which use spf13/cast). This is
+// what makes string-typed env vars usable as bool/int/float config. A value is
+// only dropped to the zero value when it genuinely cannot be parsed.
+func TestGetConfigValue_ViperTypeCoercion(t *testing.T) {
 	tests := []struct {
 		name           string
 		viperValue     interface{}
@@ -744,28 +747,28 @@ func TestGetConfigValue_ViperTypeMismatch(t *testing.T) {
 		expectedResult interface{}
 	}{
 		{
-			name:           "Viper has int, requesting string",
+			name:           "Viper has int, requesting string -> coerced",
 			viperValue:     42,
 			requestedType:  "string",
-			expectedResult: "", // zero value
+			expectedResult: "42", // cast.ToString(42)
 		},
 		{
-			name:           "Viper has string, requesting bool",
+			name:           "Viper has unparseable string, requesting bool -> zero",
 			viperValue:     "not-a-bool",
 			requestedType:  "bool",
-			expectedResult: false, // zero value
+			expectedResult: false, // not parseable as bool
 		},
 		{
-			name:           "Viper has string, requesting int",
+			name:           "Viper has unparseable string, requesting int -> zero",
 			viperValue:     "not-an-int",
 			requestedType:  "int",
-			expectedResult: 0, // zero value
+			expectedResult: 0, // not parseable as int
 		},
 		{
-			name:           "Viper has bool, requesting float64",
+			name:           "Viper has bool, requesting float64 -> coerced",
 			viperValue:     true,
 			requestedType:  "float64",
-			expectedResult: 0.0, // zero value
+			expectedResult: 1.0, // cast.ToFloat64(true)
 		},
 	}
 
@@ -783,20 +786,20 @@ func TestGetConfigValue_ViperTypeMismatch(t *testing.T) {
 			cmd.Flags().Float64("float", 0.0, "")
 
 			// EXECUTION & ASSERTION PHASE
-			// When viper has wrong type and flag not set, should return zero value
+			// The value is coerced to the requested type (zero only when unparseable).
 			switch tt.requestedType {
 			case "string":
 				result := getConfigValueWithFlags[string](cmd, "str", "test.key")
-				assert.Equal(t, tt.expectedResult.(string), result, "Should return zero value for type mismatch")
+				assert.Equal(t, tt.expectedResult.(string), result, "value should be coerced to string")
 			case "bool":
 				result := getConfigValueWithFlags[bool](cmd, "bool", "test.key")
-				assert.Equal(t, tt.expectedResult.(bool), result, "Should return zero value for type mismatch")
+				assert.Equal(t, tt.expectedResult.(bool), result, "value should be coerced to bool (zero when unparseable)")
 			case "int":
 				result := getConfigValueWithFlags[int](cmd, "int", "test.key")
-				assert.Equal(t, tt.expectedResult.(int), result, "Should return zero value for type mismatch")
+				assert.Equal(t, tt.expectedResult.(int), result, "value should be coerced to int (zero when unparseable)")
 			case "float64":
 				result := getConfigValueWithFlags[float64](cmd, "float", "test.key")
-				assert.Equal(t, tt.expectedResult.(float64), result, "Should return zero value for type mismatch")
+				assert.Equal(t, tt.expectedResult.(float64), result, "value should be coerced to float64")
 			}
 		})
 	}

--- a/docs/config-template.yaml
+++ b/docs/config-template.yaml
@@ -1,6 +1,9 @@
 app:
-  # Logging level for the application (trace, debug, info, warn, error, fatal, panic)
+  # Logging level for the application (trace, debug, info, warn, error, fatal, panic). Used as console level if app.log.console_level is not set.
   log_level: debug
+
+  # Output format: text (human-readable) or json (machine-readable)
+  output_format: json
 
   docs:
     # Output format for documentation (markdown, yaml)
@@ -8,6 +11,22 @@ app:
 
     # Output file for documentation (defaults to stdout)
     output_file: /path/to/output.md
+
+  check:
+    # Stop on first failed check
+    fail_fast: true
+
+    # Show verbose output including command details
+    verbose: true
+
+    # Run checks within each category in parallel (disable with --parallel=false)
+    parallel: false
+
+    # Filter to specific categories (comma-separated: environment,quality,architecture,security,dependencies,tests)
+    category: security,tests
+
+    # Show duration for each check in the output
+    timing: false
 
   ping:
     # Default message to display for the ping command
@@ -18,4 +37,41 @@ app:
 
     # Enable interactive UI for the ping command
     ui: true
+
+  log:
+    # Console log level (trace, debug, info, warn, error, fatal, panic). If empty, uses app.log_level.
+    console_level: info
+
+    # Enable file logging to capture detailed logs
+    file_enabled: true
+
+    # Path to the log file (created with secure 0600 permissions)
+    file_path: /var/log/ckeletin-go/app.log
+
+    # File log level (trace, debug, info, warn, error, fatal, panic)
+    file_level: debug
+
+    # Enable colored console output (auto, true, false). Auto detects TTY.
+    color_enabled: true
+
+    # Maximum size in megabytes before log file is rotated
+    file_max_size: 100
+
+    # Maximum number of old log files to retain
+    file_max_backups: 3
+
+    # Maximum number of days to retain old log files
+    file_max_age: 28
+
+    # Compress rotated log files with gzip
+    file_compress: true
+
+    # Enable log sampling for high-volume scenarios
+    sampling_enabled: true
+
+    # Number of messages to log per second before sampling
+    sampling_initial: 100
+
+    # Number of messages to log thereafter per second
+    sampling_thereafter: 100
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,7 +8,7 @@ Configuration can be provided in multiple ways, in order of precedence:
 
 1. Command-line flags
 2. Environment variables (with prefix `CKELETIN_GO_`)
-3. Configuration file (~/.ckeletin-go.yaml)
+3. Configuration file (~/.config/ckeletin-go/config.yaml)
 4. Default values
 
 ## Configuration Options
@@ -28,20 +28,29 @@ Configuration can be provided in multiple ways, in order of precedence:
 | `app.log.sampling_enabled` | bool | `false` | `CKELETIN_GO_APP_LOG_SAMPLING_ENABLED` | Enable log sampling for high-volume scenarios |
 | `app.log.sampling_initial` | int | `100` | `CKELETIN_GO_APP_LOG_SAMPLING_INITIAL` | Number of messages to log per second before sampling |
 | `app.log.sampling_thereafter` | int | `100` | `CKELETIN_GO_APP_LOG_SAMPLING_THEREAFTER` | Number of messages to log thereafter per second |
+| `app.output_format` | string | `text` | `CKELETIN_GO_APP_OUTPUT_FORMAT` | Output format: text (human-readable) or json (machine-readable) |
 | `app.docs.output_format` | string | `markdown` | `CKELETIN_GO_APP_DOCS_OUTPUT_FORMAT` | Output format for documentation (markdown, yaml) |
 | `app.docs.output_file` | string | `` | `CKELETIN_GO_APP_DOCS_OUTPUT_FILE` | Output file for documentation (defaults to stdout) |
+| `app.check.fail_fast` | bool | `false` | `CKELETIN_GO_APP_CHECK_FAIL_FAST` | Stop on first failed check |
+| `app.check.verbose` | bool | `false` | `CKELETIN_GO_APP_CHECK_VERBOSE` | Show verbose output including command details |
+| `app.check.parallel` | bool | `true` | `CKELETIN_GO_APP_CHECK_PARALLEL` | Run checks within each category in parallel (disable with --parallel=false) |
+| `app.check.category` | string | `` | `CKELETIN_GO_APP_CHECK_CATEGORY` | Filter to specific categories (comma-separated: environment,quality,architecture,security,dependencies,tests) |
+| `app.check.timing` | bool | `true` | `CKELETIN_GO_APP_CHECK_TIMING` | Show duration for each check in the output |
 | `app.ping.output_message` | string | `Pong` | `CKELETIN_GO_APP_PING_OUTPUT_MESSAGE` | Default message to display for the ping command |
 | `app.ping.output_color` | string | `white` | `CKELETIN_GO_APP_PING_OUTPUT_COLOR` | Text color for ping command output (white, red, green, blue, cyan, yellow, magenta) |
 | `app.ping.ui` | bool | `false` | `CKELETIN_GO_APP_PING_UI` | Enable interactive UI for the ping command |
 
 ## Example Configuration
 
-### YAML Configuration File (.ckeletin-go.yaml)
+### YAML Configuration File (config.yaml)
 
 ```yaml
 app:
   # Logging level for the application (trace, debug, info, warn, error, fatal, panic). Used as console level if app.log.console_level is not set.
   log_level: debug
+
+  # Output format: text (human-readable) or json (machine-readable)
+  output_format: json
 
   log:
     # Console log level (trace, debug, info, warn, error, fatal, panic). If empty, uses app.log_level.
@@ -86,6 +95,22 @@ app:
 
     # Output file for documentation (defaults to stdout)
     output_file: /path/to/output.md
+
+  check:
+    # Stop on first failed check
+    fail_fast: true
+
+    # Show verbose output including command details
+    verbose: true
+
+    # Run checks within each category in parallel (disable with --parallel=false)
+    parallel: false
+
+    # Filter to specific categories (comma-separated: environment,quality,architecture,security,dependencies,tests)
+    category: security,tests
+
+    # Show duration for each check in the output
+    timing: false
 
   ping:
     # Default message to display for the ping command
@@ -141,11 +166,29 @@ export CKELETIN_GO_APP_LOG_SAMPLING_INITIAL=100
 # Number of messages to log thereafter per second
 export CKELETIN_GO_APP_LOG_SAMPLING_THEREAFTER=100
 
+# Output format: text (human-readable) or json (machine-readable)
+export CKELETIN_GO_APP_OUTPUT_FORMAT=json
+
 # Output format for documentation (markdown, yaml)
 export CKELETIN_GO_APP_DOCS_OUTPUT_FORMAT=yaml
 
 # Output file for documentation (defaults to stdout)
 export CKELETIN_GO_APP_DOCS_OUTPUT_FILE=/path/to/output.md
+
+# Stop on first failed check
+export CKELETIN_GO_APP_CHECK_FAIL_FAST=true
+
+# Show verbose output including command details
+export CKELETIN_GO_APP_CHECK_VERBOSE=true
+
+# Run checks within each category in parallel (disable with --parallel=false)
+export CKELETIN_GO_APP_CHECK_PARALLEL=false
+
+# Filter to specific categories (comma-separated: environment,quality,architecture,security,dependencies,tests)
+export CKELETIN_GO_APP_CHECK_CATEGORY=security,tests
+
+# Show duration for each check in the output
+export CKELETIN_GO_APP_CHECK_TIMING=false
 
 # Default message to display for the ping command
 export CKELETIN_GO_APP_PING_OUTPUT_MESSAGE=Hello World!

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -106,7 +106,7 @@ Generate documentation for all available options:
 ./ckeletin-go docs config --format yaml
 
 # Save to file
-./ckeletin-go docs config --output docs/configuration.md
+./ckeletin-go docs config --output-file docs/configuration.md
 ```
 
 ## Quick Start Examples

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/mattn/go-isatty v0.0.22
 	github.com/rs/zerolog v1.35.1
 	github.com/sebdah/goldie/v2 v2.8.0
+	github.com/spf13/cast v1.10.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
@@ -45,7 +46,6 @@ require (
 	github.com/sergi/go-diff v1.0.0 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
-	github.com/spf13/cast v1.10.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/internal/check/executor.go
+++ b/internal/check/executor.go
@@ -229,8 +229,11 @@ func (e *Executor) Execute(ctx context.Context) error {
 		}); err != nil {
 			return fmt.Errorf("failed to write JSON output: %w", err)
 		}
-		// Return nil — the JSON envelope already communicates success/failure.
-		// Returning an error here would cause main.go to emit a second envelope.
+		// The single envelope is written. Signal a non-zero exit on failure
+		// (without main.go emitting a second envelope); nil on success.
+		if totalFailed > 0 {
+			return output.ErrRendered
+		}
 		return nil
 	}
 

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -12,6 +13,11 @@ import (
 
 func run() int {
 	if err := cmd.Execute(); err != nil {
+		// The command already emitted its single JSON envelope; exit non-zero
+		// without rendering a second envelope.
+		if errors.Is(err, output.ErrRendered) {
+			return 1
+		}
 		if output.IsJSONMode() {
 			_ = output.RenderJSON(os.Stdout, output.JSONEnvelope{
 				Status:  "error",

--- a/test/integration/coverage_gate_test.go
+++ b/test/integration/coverage_gate_test.go
@@ -1,0 +1,57 @@
+// test/integration/coverage_gate_test.go
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCheckTaskEnforcesCoverageGate guards that the mandatory `task check` path
+// still wires in the 85% project-coverage gate (test:coverage:project). If a
+// future .ckeletin/ sync, merge, or refactor drops that step, `task check` would
+// silently stop enforcing the coverage floor (the binary/bash check only
+// measures coverage, it does not gate on it). This test fails loudly instead.
+func TestCheckTaskEnforcesCoverageGate(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(root, ".ckeletin", "Taskfile.yml"))
+	require.NoError(t, err)
+
+	block := topLevelTaskBlock(string(data), "check")
+	require.NotEmpty(t, block, "could not locate the 'check:' task in .ckeletin/Taskfile.yml")
+	assert.Contains(t, block, "test:coverage:project",
+		"the 'check' task must invoke test:coverage:project so the 85% coverage gate is enforced in `task check`")
+}
+
+// topLevelTaskBlock returns the body lines of the named 2-space-indented task,
+// up to (but excluding) the next top-level task.
+func topLevelTaskBlock(content, name string) string {
+	isTopTask := func(line string) bool {
+		return len(line) >= 3 && line[0] == ' ' && line[1] == ' ' &&
+			line[2] != ' ' && line[2] != '-' && line[2] != '#'
+	}
+	var body []string
+	in := false
+	for _, line := range strings.Split(content, "\n") {
+		if isTopTask(line) {
+			if in {
+				break // reached the next task
+			}
+			if strings.TrimSpace(line) == name+":" {
+				in = true
+			}
+			continue
+		}
+		if in {
+			body = append(body, line)
+		}
+	}
+	return strings.Join(body, "\n")
+}


### PR DESCRIPTION
Addresses all six findings from an external code review (each independently verified + reproduced), plus the items surfaced by a follow-up multi-agent PR review. `CHANGELOG.md` `[Unreleased]` is updated (Keep a Changelog 1.1.0). `task check` green (coverage 89.9%), layering + license + conformance clean.

## ⚠️ Breaking / behaviour-affecting changes (see CHANGELOG)
- **BREAKING:** `docs config` output-file flag renamed `--output` → **`--output-file`** (the global `--output` now consistently selects format). Update scripts using `docs config --output <path>`.
- **`config validate --output json` / `check --output json` now exit non-zero on failure** (previously exited `0`; result was only in the envelope `status`). CI that gates on `$?` will now detect failures.
- **Environment variables for non-string config are now honored** (e.g. `CKELETIN_GO_APP_PING_UI=true`) — previously silently ignored.

## Fixes
1. **`7a7ee54`** `config validate --output json` emits exactly one JSON envelope (was mixing human text + JSON).
2. **`b88ed74`** Non-string env vars coerced (`coerceViperValue` via `spf13/cast`) instead of dropped to zero.
3. **`c355f16`** `completion zsh|fish|powershell` emit the correct script (was always bash); unknown shell rejected.
4. **`8574dcb`** `docs config` flag rename (breaking, above) — generation tasks + docs updated.
5. **`20e57b8`** `task check` now enforces the 85% project coverage gate (was measured, not gated).
6. **`ae83c51`** Stale docs refreshed (Go version → `.go-version`; default config path; `app.output_format` + `app.check.*`).

## PR-review remediations
- **`e80adc0`** Exit-code fix (above) via an `output.ErrRendered` sentinel — one envelope **and** a correct exit code, applied to `config validate` and `check`.
- **`8cf41b2`** Guard test for the coverage-gate wiring + float/`[]string` coercion coverage.
- **`8ff2739`** Unparseable env values now log a `WARN` (with key + value) instead of silently becoming zero. `cast` registered as a commands-layer vendor.
- **`ae18fd5`** CHANGELOG `[Unreleased]` populated (breaking under `Changed`, fixes under `Fixed`).

## Verification
Each behaviour change has a pinning test (TDD). Three pr-review-toolkit agents (code-reviewer, test-analyzer, silent-failure-hunter) reviewed the diff read-only; their material findings are remediated above. `task check`, layering, license, and `task conform` (39/39) all pass.

Per SemVer on `0.x`, the breaking changes warrant a **minor** bump (→ `0.11.0`) at release time.