### PR TITLE
feat: v0.10.0 conformance — ENF-011 + verification taxonomy re-conform

### DIFF
--- a/conformance-mapping.yaml
+++ b/conformance-mapping.yaml
@@ -13,7 +13,7 @@
 # Simple commands with no special characters may stay as plain double-quoted
 # one-liners (e.g. "task validate:layering").
 
-spec_version: "0.9.0"
+spec_version: "0.10.0"
 
 requirements:
   # ═══════════════════════════════════════════════════════════════
@@ -190,7 +190,7 @@ requirements:
     status: met
     enforcement_level: script
     evidence: >
-      task conform validates all 41 requirement IDs are present in
+      task conform validates all 42 requirement IDs are present in
       conformance-mapping.yaml before running checks. Missing IDs
       cause the generator to fail with a non-zero exit code. The count is
       machine-verified by the ENF-008 drift guard, not hand-maintained.
@@ -226,10 +226,10 @@ requirements:
     status: met
     enforcement_level: script
     evidence: >
-      task conform automatically reports feedback signals when
-      checkable requirements lack violation tests or enforcement
-      level is above honor-system without proof. Signals are
-      structural, not volitional.
+      task conform automatically reports feedback signals when a
+      requirement's enforcement_level is above honor-system without a
+      violation test or violation evidence. Signals are structural, not
+      volitional.
     checks:
       - "grep -q 'Feedback signals' .ckeletin/scripts/conform.sh"
     violation_tests: []
@@ -314,6 +314,35 @@ requirements:
       - "grep -q 'out of sync' .ckeletin/scripts/conform.sh"
     violation_tests:
       - "test/conformance/violation_test.go::TestViolation_ConformReport_OutOfSyncRejected"
+
+  CKSPEC-ENF-011:
+    title: "Tooling robustness to nested checkouts"
+    status: met
+    enforcement_level: test
+    evidence: >
+      ckeletin-go's tree-walking scanners bound their traversal to the
+      project's own sources and do not descend into nested repository or
+      worktree checkouts. The shared exclusion lives in
+      .ckeletin/scripts/lib/check-output.sh (skips .claude/worktrees/ and any
+      directory carrying its own go.mod — a nested module is never part of
+      this module's walk); the formatter (format-go.sh) and the architecture
+      linter (.go-arch-lint.yml) apply the same bound. Surfaced by #123
+      (reported by daana-cli): a scanner descended into Claude Code's worktree
+      directory and broke on stale nested module checkouts. Verified by
+      test/integration/scanner_exclusion_test.go
+      (TestScannersExcludeClaudeWorktrees): format check, format fix, layering
+      validation, and the SAST scan each ignore a stale worktree.
+    checks:
+      - "grep -q '.claude/worktrees' .ckeletin/scripts/lib/check-output.sh"
+      - "grep -qi 'worktree' .go-arch-lint.yml"
+      - "test -f test/integration/scanner_exclusion_test.go"
+    violation_tests: []
+    violation_evidence: >
+      Removing the .claude/worktrees exclusion from check-output.sh (or the
+      arch-lint config) lets the scanners descend into nested worktree
+      checkouts again — the corresponding grep check fails, and
+      TestScannersExcludeClaudeWorktrees fails (a stale worktree's unbuildable
+      code is walked and flagged, or breaks the scan).
 
   # ═══════════════════════════════════════════════════════════════
   # Testing (CKSPEC-TEST-001 through CKSPEC-TEST-004)

--- a/conformance-mapping.yaml
+++ b/conformance-mapping.yaml
@@ -325,16 +325,18 @@ requirements:
       worktree checkouts. The shared exclusion lives in
       .ckeletin/scripts/lib/check-output.sh (skips .claude/worktrees/ and any
       directory carrying its own go.mod — a nested module is never part of
-      this module's walk); the formatter (format-go.sh) and the architecture
-      linter (.go-arch-lint.yml) apply the same bound. Surfaced by #123
-      (reported by daana-cli): a scanner descended into Claude Code's worktree
-      directory and broke on stale nested module checkouts. Verified by
-      test/integration/scanner_exclusion_test.go
+      this module's walk); the formatter (format-go.sh) shares that exclusion,
+      and the architecture linter (.go-arch-lint.yml) excludes .claude/ as well.
+      Surfaced by #123 (reported by daana-cli): a scanner descended into Claude
+      Code's worktree directory and broke on stale nested module checkouts.
+      Verified by test/integration/scanner_exclusion_test.go
       (TestScannersExcludeClaudeWorktrees): format check, format fix, layering
-      validation, and the SAST scan each ignore a stale worktree.
+      validation, and — in CI, where semgrep is present — the SAST scan each
+      ignore a stale worktree.
     checks:
       - "grep -q '.claude/worktrees' .ckeletin/scripts/lib/check-output.sh"
-      - "grep -qi 'worktree' .go-arch-lint.yml"
+      - |-
+        grep -q '\.claude' .go-arch-lint.yml
       - "test -f test/integration/scanner_exclusion_test.go"
     violation_tests: []
     violation_evidence: >

--- a/conformance-report.json
+++ b/conformance-report.json
@@ -283,7 +283,7 @@
         "test -f .ckeletin/scripts/conform.sh"
       ],
       "enforcement_level": "script",
-      "evidence": "task conform validates all 41 requirement IDs are present in conformance-mapping.yaml before running checks. Missing IDs cause the generator to fail with a non-zero exit code. The count is machine-verified by the ENF-008 drift guard, not hand-maintained.\n",
+      "evidence": "task conform validates all 42 requirement IDs are present in conformance-mapping.yaml before running checks. Missing IDs cause the generator to fail with a non-zero exit code. The count is machine-verified by the ENF-008 drift guard, not hand-maintained.\n",
       "status": "met",
       "violation_evidence": null,
       "violation_tests": [
@@ -307,7 +307,7 @@
         "grep -q 'Feedback signals' .ckeletin/scripts/conform.sh"
       ],
       "enforcement_level": "script",
-      "evidence": "task conform automatically reports feedback signals when checkable requirements lack violation tests or enforcement level is above honor-system without proof. Signals are structural, not volitional.\n",
+      "evidence": "task conform automatically reports feedback signals when a requirement's enforcement_level is above honor-system without a violation test or violation evidence. Signals are structural, not volitional.\n",
       "status": "met",
       "violation_evidence": "The violation test verifies the conform script contains feedback signal logic (string presence), not that it produces correct output \u2014 running conform.sh from within the conformance test suite causes infinite recursion. Behavioral proof: task conform output shows feedback signals when enforcement claims lack violation tests. File: .ckeletin/scripts/conform.sh (FEEDBACK_FILE logic). File: test/conformance/violation_test.go (TestViolation_ENF007).\n",
       "violation_tests": []
@@ -348,6 +348,18 @@
       "violation_tests": [
         "test/conformance/violation_test.go::TestViolation_ConformReport_OutOfSyncRejected"
       ]
+    },
+    "CKSPEC-ENF-011": {
+      "checks": [
+        "grep -q '.claude/worktrees' .ckeletin/scripts/lib/check-output.sh",
+        "grep -qi 'worktree' .go-arch-lint.yml",
+        "test -f test/integration/scanner_exclusion_test.go"
+      ],
+      "enforcement_level": "test",
+      "evidence": "ckeletin-go's tree-walking scanners bound their traversal to the project's own sources and do not descend into nested repository or worktree checkouts. The shared exclusion lives in .ckeletin/scripts/lib/check-output.sh (skips .claude/worktrees/ and any directory carrying its own go.mod \u2014 a nested module is never part of this module's walk); the formatter (format-go.sh) and the architecture linter (.go-arch-lint.yml) apply the same bound. Surfaced by #123 (reported by daana-cli): a scanner descended into Claude Code's worktree directory and broke on stale nested module checkouts. Verified by test/integration/scanner_exclusion_test.go (TestScannersExcludeClaudeWorktrees): format check, format fix, layering validation, and the SAST scan each ignore a stale worktree.\n",
+      "status": "met",
+      "violation_evidence": "Removing the .claude/worktrees exclusion from check-output.sh (or the arch-lint config) lets the scanners descend into nested worktree checkouts again \u2014 the corresponding grep check fails, and TestScannersExcludeClaudeWorktrees fails (a stale worktree's unbuildable code is walked and flagged, or breaks the scan).\n",
+      "violation_tests": []
     },
     "CKSPEC-OUT-001": {
       "checks": [
@@ -461,12 +473,12 @@
       "violation_tests": []
     }
   },
-  "spec_version": "0.9.0",
+  "spec_version": "0.10.0",
   "summary": {
     "deferred": 0,
-    "met": 41,
+    "met": 42,
     "partial": 0,
     "passed": true,
-    "total": 41
+    "total": 42
   }
 }

--- a/conformance-report.json
+++ b/conformance-report.json
@@ -352,11 +352,11 @@
     "CKSPEC-ENF-011": {
       "checks": [
         "grep -q '.claude/worktrees' .ckeletin/scripts/lib/check-output.sh",
-        "grep -qi 'worktree' .go-arch-lint.yml",
+        "grep -q '\\.claude' .go-arch-lint.yml",
         "test -f test/integration/scanner_exclusion_test.go"
       ],
       "enforcement_level": "test",
-      "evidence": "ckeletin-go's tree-walking scanners bound their traversal to the project's own sources and do not descend into nested repository or worktree checkouts. The shared exclusion lives in .ckeletin/scripts/lib/check-output.sh (skips .claude/worktrees/ and any directory carrying its own go.mod \u2014 a nested module is never part of this module's walk); the formatter (format-go.sh) and the architecture linter (.go-arch-lint.yml) apply the same bound. Surfaced by #123 (reported by daana-cli): a scanner descended into Claude Code's worktree directory and broke on stale nested module checkouts. Verified by test/integration/scanner_exclusion_test.go (TestScannersExcludeClaudeWorktrees): format check, format fix, layering validation, and the SAST scan each ignore a stale worktree.\n",
+      "evidence": "ckeletin-go's tree-walking scanners bound their traversal to the project's own sources and do not descend into nested repository or worktree checkouts. The shared exclusion lives in .ckeletin/scripts/lib/check-output.sh (skips .claude/worktrees/ and any directory carrying its own go.mod \u2014 a nested module is never part of this module's walk); the formatter (format-go.sh) shares that exclusion, and the architecture linter (.go-arch-lint.yml) excludes .claude/ as well. Surfaced by #123 (reported by daana-cli): a scanner descended into Claude Code's worktree directory and broke on stale nested module checkouts. Verified by test/integration/scanner_exclusion_test.go (TestScannersExcludeClaudeWorktrees): format check, format fix, layering validation, and \u2014 in CI, where semgrep is present \u2014 the SAST scan each ignore a stale worktree.\n",
       "status": "met",
       "violation_evidence": "Removing the .claude/worktrees exclusion from check-output.sh (or the arch-lint config) lets the scanners descend into nested worktree checkouts again \u2014 the corresponding grep check fails, and TestScannersExcludeClaudeWorktrees fails (a stale worktree's unbuildable code is walked and flagged, or breaks the scan).\n",
       "violation_tests": []


### PR DESCRIPTION
## go half of the v0.10.0 schema drop (ENF-011 + verification taxonomy + structural)

Part of the coordinated 3-repo v0.10.0 landing (`peiman/ckeletin` #45 / #16/#34/#44). Merging to go `main` publishes go's 0.10.0 conformance report for the spec aggregator.

### Changes
- **CKSPEC-ENF-011** (new, 42nd): tooling robustness to nested checkouts — go's tree-walking scanners exclude `.claude/worktrees/` nested checkouts (#123); `enforcement_level: test` (`TestScannersExcludeClaudeWorktrees`).
- **#34 `checkable`→`verification`:** no go generator change — go's `conform` never functionally read `checkable`; only fixed stale "checkable" prose in ENF-007 evidence to describe what `conform` actually keys off (`enforcement_level` above honor-system without proof).
- **#16 retire `design` / add `structural`:** no change — go has **zero** `design` entries and `test` survives the enum; all enforcement levels already valid.
- `spec_version` 0.9.0→0.10.0; ENF-005 count 41→42; report regenerated.

### Verification
- `conform` passes **42/42** against the vendored 0.10.0 spec (report-sync PASS, 0 failed checks).
- Pre-push green: coverage + full scaffold suite (147 tests) — **no `--no-verify` needed**; #123's golangci cache isolation retired the prior flake.

### Vendored-ahead
go `main`'s conform fetches the still-0.9.0 published spec until #45 merges; completeness is a subset check so it passes (version-mismatch warning), self-resolving on merge.

https://claude.ai/code/session_01MNgRHnHMA2bakeFnSBHWnp
