### PR TITLE
test: automated reject-test for the ENF-008 anchor-resolution gate (closes #127)

### DIFF
--- a/.ckeletin/scripts/conform.sh
+++ b/.ckeletin/scripts/conform.sh
@@ -48,6 +48,14 @@ if [ "$CURRENT_MODULE" != "$REFERENCE_MODULE" ]; then
     exit 0
 fi
 
+# Sourced helper: ENF-008 violation-test anchor resolution. Extracted so the
+# resolution logic is unit-tested directly (test/conformance/violation_test.go
+# ::TestViolation_ENF008_AnchorResolution) without re-running conform (which
+# would recurse). Behaviour here is identical to the prior inline loop body.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/anchor.sh
+source "${SCRIPT_DIR}/lib/anchor.sh"
+
 MAPPING_FILE="conformance-mapping.yaml"
 FAIL_FILE=$(mktemp)
 FEEDBACK_FILE=$(mktemp)
@@ -303,27 +311,11 @@ for req_id in $REQ_IDS; do
             echo "$req_id: claims $enforcement but has no violation test or evidence" >> "$FEEDBACK_FILE"
         elif [[ -n "$vtests" ]]; then
             echo "$vtests" | while IFS= read -r vt; do
-                [[ -z "$vt" ]] && continue
                 # ENF-008 (anchor validity): an anchor MUST resolve, not merely
-                # be present. A file::symbol violation_test must name a file that
-                # exists AND (when a symbol is given) a symbol defined in it. A
-                # dangling anchor — e.g. a renamed test still cited by its old
-                # name — is no better than no anchor, so it HARD-FAILS the
-                # generator rather than emitting a stale claim.
-                vt_file="${vt%%::*}"
-                vt_symbol="${vt#*::}"
-                if [[ -n "$vt_file" && ! -f "$vt_file" ]]; then
-                    echo "$req_id: dangling anchor — violation test file not found: $vt_file (ENF-008)" >> "$FAIL_FILE"
-                elif [[ "$vt" == *::* && -z "$vt_symbol" ]]; then
-                    # A '::' was written but no symbol followed — a garbled anchor
-                    # must not pass as file-only.
-                    echo "$req_id: dangling anchor — empty symbol after '::' in '$vt' (ENF-008)" >> "$FAIL_FILE"
-                elif [[ -n "$vt_symbol" && "$vt_symbol" != "$vt" ]] && \
-                     ! grep -qE "func[[:space:]]+(\([^)]*\)[[:space:]]+)?${vt_symbol}\b" "$vt_file"; then
-                    # The optional (receiver) group also resolves method-style
-                    # tests, func (s *Suite) TestX, not just free functions.
-                    echo "$req_id: dangling anchor — symbol '$vt_symbol' not found in $vt_file (ENF-008)" >> "$FAIL_FILE"
-                fi
+                # be present. anchor_resolve hard-fails (appends to FAIL_FILE) a
+                # dangling file::symbol — missing file, missing symbol, or empty
+                # symbol after '::' — so a stale anchor can never pass as proof.
+                anchor_resolve "$vt" "$FAIL_FILE" "$req_id"
             done
         fi
         # violation_evidence is accepted at face value if it exists —

--- a/.ckeletin/scripts/lib/anchor.sh
+++ b/.ckeletin/scripts/lib/anchor.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Violation-test anchor resolution for CKSPEC-ENF-008.
+# Usage: source scripts/lib/anchor.sh
+#
+# Sourced library: deliberately no `set -eo pipefail` here — shell options
+# would leak into (or fight with) the sourcing script, which owns strict mode.
+
+# anchor_resolve <anchor> <fail_file> [req_id]
+#
+# ENF-008: an evidence anchor MUST resolve, not merely be present. For a
+# violation_test `file::symbol` anchor that means the file must exist AND, when
+# a symbol is named, a function with that symbol must be defined in it. A
+# dangling anchor — a renamed/removed test still cited by its old name, or a
+# garbled `file::` with no symbol — appends a "dangling anchor" line to
+# <fail_file>; the caller treats a non-empty fail file as a hard failure.
+# The optional receiver group also resolves method-style tests,
+# func (s *Suite) TestX, not just free functions.
+anchor_resolve() {
+    local vt="$1" fail_file="$2" req_id="${3:-?}"
+    [[ -z "$vt" ]] && return 0
+    local vt_file="${vt%%::*}"
+    local vt_symbol="${vt#*::}"
+    if [[ -n "$vt_file" && ! -f "$vt_file" ]]; then
+        echo "$req_id: dangling anchor — violation test file not found: $vt_file (ENF-008)" >> "$fail_file"
+    elif [[ "$vt" == *::* && -z "$vt_symbol" ]]; then
+        echo "$req_id: dangling anchor — empty symbol after '::' in '$vt' (ENF-008)" >> "$fail_file"
+    elif [[ -n "$vt_symbol" && "$vt_symbol" != "$vt" ]] && \
+         ! grep -qE "func[[:space:]]+(\([^)]*\)[[:space:]]+)?${vt_symbol}\b" "$vt_file"; then
+        echo "$req_id: dangling anchor — symbol '$vt_symbol' not found in $vt_file (ENF-008)" >> "$fail_file"
+    fi
+}

--- a/conformance-mapping.yaml
+++ b/conformance-mapping.yaml
@@ -254,26 +254,23 @@ requirements:
       v0.11.0): a violation_test `file::symbol` anchor hard-fails when the file
       is missing or the named symbol is not defined in it — a renamed/removed
       test still cited by its old name is a dangling anchor and is rejected, so
-      a stale anchor can never pass as proof. Met requirements are tallied as
+      a stale anchor can never pass as proof. The resolution logic is extracted
+      to .ckeletin/scripts/lib/anchor.sh (anchor_resolve) and unit-tested across
+      all branches by the violation_test below. Met requirements are tallied as
       machine-anchored vs analysis-with-evidence and the split is printed. The
       same gate also catches prose count drift ("all N requirement").
     checks:
       - "grep -q 'machine-anchored' .ckeletin/scripts/conform.sh"
       - "grep -q 'met but unanchored' .ckeletin/scripts/conform.sh"
-      - "grep -q 'dangling anchor' .ckeletin/scripts/conform.sh"
-    violation_tests: []
+      - "grep -q 'dangling anchor' .ckeletin/scripts/lib/anchor.sh"
+      - "grep -q 'anchor_resolve' .ckeletin/scripts/conform.sh"
+    violation_tests:
+      - "test/conformance/violation_test.go::TestViolation_ENF008_AnchorResolution"
     violation_evidence: >
-      The anchoring gate is conform.sh itself, so it is not cited as an
-      in-mapping violation_test (that would re-run the generator from inside
-      the suite — recursion). An external fixture test — run conform against a
-      mapping with a deliberately dangling anchor, outside the suite — is the
-      regression guard and is tracked as a follow-up. Behavioral proof
-      (verified): stripping a met requirement's checks and violation_evidence
-      makes task conform fail with "met but unanchored"; citing a renamed or
-      nonexistent test symbol makes it fail with "dangling anchor ... not
-      found"; a `file::` anchor with an empty symbol fails too.
-      File: .ckeletin/scripts/conform.sh (ENF-008 anchoring gate + the
-      automated-vs-analysis tally + the anchor-resolution check).
+      The presence/tally half: stripping a met requirement's checks and
+      violation_evidence makes task conform fail with "met but unanchored".
+      File: .ckeletin/scripts/conform.sh (anchoring gate + tally) +
+      .ckeletin/scripts/lib/anchor.sh (resolution).
 
   CKSPEC-ENF-009:
     title: "Conformance gate on release"

--- a/conformance-report.json
+++ b/conformance-report.json
@@ -316,13 +316,16 @@
       "checks": [
         "grep -q 'machine-anchored' .ckeletin/scripts/conform.sh",
         "grep -q 'met but unanchored' .ckeletin/scripts/conform.sh",
-        "grep -q 'dangling anchor' .ckeletin/scripts/conform.sh"
+        "grep -q 'dangling anchor' .ckeletin/scripts/lib/anchor.sh",
+        "grep -q 'anchor_resolve' .ckeletin/scripts/conform.sh"
       ],
       "enforcement_level": "script",
-      "evidence": "conform.sh fails if any requirement claimed met lacks both an automated check and a violation_evidence anchor \u2014 no unanchored met-claims. Anchors must also RESOLVE, not merely be present (#15, v0.11.0): a violation_test `file::symbol` anchor hard-fails when the file is missing or the named symbol is not defined in it \u2014 a renamed/removed test still cited by its old name is a dangling anchor and is rejected, so a stale anchor can never pass as proof. Met requirements are tallied as machine-anchored vs analysis-with-evidence and the split is printed. The same gate also catches prose count drift (\"all N requirement\").\n",
+      "evidence": "conform.sh fails if any requirement claimed met lacks both an automated check and a violation_evidence anchor \u2014 no unanchored met-claims. Anchors must also RESOLVE, not merely be present (#15, v0.11.0): a violation_test `file::symbol` anchor hard-fails when the file is missing or the named symbol is not defined in it \u2014 a renamed/removed test still cited by its old name is a dangling anchor and is rejected, so a stale anchor can never pass as proof. The resolution logic is extracted to .ckeletin/scripts/lib/anchor.sh (anchor_resolve) and unit-tested across all branches by the violation_test below. Met requirements are tallied as machine-anchored vs analysis-with-evidence and the split is printed. The same gate also catches prose count drift (\"all N requirement\").\n",
       "status": "met",
-      "violation_evidence": "The anchoring gate is conform.sh itself, so it is not cited as an in-mapping violation_test (that would re-run the generator from inside the suite \u2014 recursion). An external fixture test \u2014 run conform against a mapping with a deliberately dangling anchor, outside the suite \u2014 is the regression guard and is tracked as a follow-up. Behavioral proof (verified): stripping a met requirement's checks and violation_evidence makes task conform fail with \"met but unanchored\"; citing a renamed or nonexistent test symbol makes it fail with \"dangling anchor ... not found\"; a `file::` anchor with an empty symbol fails too. File: .ckeletin/scripts/conform.sh (ENF-008 anchoring gate + the automated-vs-analysis tally + the anchor-resolution check).\n",
-      "violation_tests": []
+      "violation_evidence": "The presence/tally half: stripping a met requirement's checks and violation_evidence makes task conform fail with \"met but unanchored\". File: .ckeletin/scripts/conform.sh (anchoring gate + tally) + .ckeletin/scripts/lib/anchor.sh (resolution).\n",
+      "violation_tests": [
+        "test/conformance/violation_test.go::TestViolation_ENF008_AnchorResolution"
+      ]
     },
     "CKSPEC-ENF-009": {
       "checks": [

--- a/test/conformance/violation_test.go
+++ b/test/conformance/violation_test.go
@@ -823,3 +823,49 @@ func TestViolation_AGENT002_ProviderInstructionCaught(t *testing.T) {
 	assert.NotEqual(t, 0, runAgainst(t, violated),
 		"the AGENT-002 check must catch a provider-specific instruction line")
 }
+
+// TestViolation_ENF008_AnchorResolution proves the ENF-008 anchor-resolution
+// gate flags a dangling violation_test anchor — the regression guard for #15
+// (issue #127). It exercises the real shell helper
+// .ckeletin/scripts/lib/anchor.sh::anchor_resolve against fixtures, so it tests
+// the actual gate logic (not a copy) and never invokes conform.sh — no
+// recursion. anchor_resolve appends to the same FAIL_FILE the "met but
+// unanchored" gate uses, which conform turns into a non-zero exit.
+func TestViolation_ENF008_AnchorResolution(t *testing.T) {
+	lib := filepath.Join(projectRoot(t), ".ckeletin", "scripts", "lib", "anchor.sh")
+	require.FileExists(t, lib)
+
+	dir := t.TempDir()
+	fixture := filepath.Join(dir, "fixture.go")
+	require.NoError(t, os.WriteFile(fixture,
+		[]byte("package x\nfunc TestReal(t *T) {}\nfunc (s *S) TestMethod(t *T) {}\n"), 0o644))
+
+	// run sources anchor.sh, calls anchor_resolve on the anchor, and returns
+	// what was recorded to the fail file (empty == resolved, no failure).
+	// Values are passed as bash positional args ($1/$2/$3), never interpolated
+	// into the script string — no shell-injection surface.
+	const script = `source "$1"; anchor_resolve "$2" "$3" REQ`
+	run := func(anchor string) string {
+		ff := filepath.Join(dir, "fail")
+		_ = os.Remove(ff)
+		out, err := exec.Command("bash", "-c", script, "_", lib, anchor, ff).CombinedOutput()
+		require.NoError(t, err, "anchor_resolve must not error: %s", out)
+		require.Empty(t, strings.TrimSpace(string(out)),
+			"anchor_resolve records to the fail file, not stdout")
+		b, _ := os.ReadFile(ff)
+		return string(b)
+	}
+
+	// Resolving anchors record nothing.
+	assert.Empty(t, run(fixture+"::TestReal"), "existing free function resolves")
+	assert.Empty(t, run(fixture+"::TestMethod"), "method-style test resolves")
+	assert.Empty(t, run(fixture), "bare existing file (no symbol) resolves")
+
+	// Dangling anchors are flagged as such — the regression the gate exists to catch.
+	assert.Contains(t, run(filepath.Join(dir, "missing.go")+"::TestReal"), "file not found",
+		"missing file must be flagged dangling")
+	assert.Contains(t, run(fixture+"::TestGone"), "not found",
+		"missing symbol must be flagged dangling")
+	assert.Contains(t, run(fixture+"::"), "empty symbol",
+		"empty symbol after :: must be flagged dangling")
+}


### PR DESCRIPTION
## Automated reject-test for the ENF-008 dangling-anchor gate

Closes #127 (follow-up from PR #126 review).

The #15 anchor-resolution gate had no automated test that it *rejects* a dangling anchor — only manual verification + a string-presence check. This adds one, the right way:

- **Extracted** the resolution logic from `conform.sh` into a sourceable helper `.ckeletin/scripts/lib/anchor.sh::anchor_resolve`. conform.sh now sources + calls it; behavior is identical.
- **`TestViolation_ENF008_AnchorResolution`** (tag `conformance`) runs the real helper against fixtures — covering all branches: resolving free function / method-style test / bare file → no failure; missing file / missing symbol / empty `file::` symbol → flagged dangling. It tests the actual gate logic (not a copy) and never invokes `conform.sh`, so **no recursion**.
- **ENF-008** is now anchored by that test (`violation_tests`) instead of analysis-only; the dangling-anchor check now greps `anchor.sh` (where the logic lives) and asserts conform wires `anchor_resolve`.

### Verification
- conform **42/42** vs vendored 0.11.0 (all real anchors resolve through the extracted helper).
- default + conformance-tagged suites green; the new test passes.
- End-to-end: a dangling symbol through conform's exact `echo | while` subshell pattern writes to `FAIL_FILE` → hard-fail (verified).

https://claude.ai/code/session_01MNgRHnHMA2bakeFnSBHWnp
